### PR TITLE
Update series.md

### DIFF
--- a/api/network/series.md
+++ b/api/network/series.md
@@ -1,4 +1,4 @@
-# The `series` Command
+# `series` Command
 
 ## Description
 

--- a/api/network/series.md
+++ b/api/network/series.md
@@ -1,8 +1,8 @@
-# `series` Command
+# The `series` Command
 
 ## Description
 
-Insert a timestamped value (number or text) into the specified time series, uniquely identified by a composite primary key consisting of the entity, metric, and optional `key=value` tags.
+Use the `series`command to insert a timestamped value (number or text) into a specified time series, uniquely identified by a composite primary key consisting of an entity, metric, and optional `key=value` tag(s).
 
 ## Syntax
 
@@ -10,7 +10,7 @@ Insert a timestamped value (number or text) into the specified time series, uniq
 series d:{iso-date} e:{entity} t:{tag-1}={val-1} m:{metric-1}={number}
 ```
 
-The command may include multiple values for different metrics, inheriting the same entity, time, and tags.
+The command may include multiple values for different metrics, which inherit the same entity, time, and tags.
 
 ```css
 series d:{iso-date} e:{entity} t:{tag-1}={val-1} m:{metric-1}={number} m:{metric-2}={number} x:{metric-3}={text}
@@ -27,7 +27,7 @@ series d:{iso-date} e:{entity} t:{tag-1}={val-1} m:{metric-1}={number} m:{metric
 | ms        | integer         | Time in UNIX milliseconds. |
 | s         | integer         | Time in UNIX seconds. |
 | t         | string:string   | Tag name and text value. _Multiple._ |
-| a         | boolean         | Text append flag. If set to `true`, causes the text value to be appended to the previous text value with the same timestamp. |
+| a         | boolean         | Text append flag. If set to `true`, it causes the text value to be appended to the previous text value with the same timestamp. |
 
 > At least one numeric metric `m:` or text metric `x:` is required.
 
@@ -37,7 +37,7 @@ series d:{iso-date} e:{entity} t:{tag-1}={val-1} m:{metric-1}={number} m:{metric
 
 ### ABNF Syntax
 
-Rules inherited from [Base ABNF](base-abnf.md).
+Rules are inherited from [Base ABNF](base-abnf.md).
 
 ```properties
   ; entity and at least one metric is required
@@ -61,22 +61,22 @@ To insert metric samples with another data type, create or update metric propert
 
 ## New Records
 
-If the command references non-existent entities, metrics, or tags, such objects will be created as new records and registered automatically.
+If the command references non-existent entities, metrics, or tags, they will be created as new records and registered automatically.
 
-Entity, metric, and tag names are case-insensitive and will be converted to lower case when inserted, whereas tag values are case-sensitive.
+Entity, metric, and tag names are case-insensitive and will be converted to lower case when inserted. Tag values are case-sensitive.
 
 
 ## Examples
 
-* Insert numeric value '72' for metric 'cpu_used', entity 'server001' recorded on March 4, 2015 at 15:14:40 GMT (Unix epoch seconds = 1425482080).
+* Insert the numeric value '72' for the metric 'cpu_used' from the entity 'server001' recorded on March 4, 2015 at 15:14:40 GMT (Unix epoch seconds = 1425482080).
 
 ```ls
 series e:server001 m:cpu_used=72.0 s:1425482080
 ```
 
 * Insert samples for two series:
-  - Insert numeric value '72' for metric 'cpu_used', entity 'server001' recorded on March 4, 2015 at 15:14:40 GMT
-  - Insert numeric value '94.5' for metric 'memory_used' and the same entity and time.
+  - Insert the numeric value '72' for the metric 'cpu_used' from the entity 'server001' recorded on March 4, 2015 at 15:14:40 GMT
+  - Insert the numeric value '94.5' for the metric 'memory_used' and the same entity and time.
 
 ```ls
 series e:server001 m:cpu_used=72.0 m:memory_used=94.5 s:1425482080
@@ -94,7 +94,7 @@ series e:server001 m:cpu_used=72.0 m:memory_used=94.5 ms:1425482080000
 series e:server001 m:cpu_used=72.0 m:memory_used=94.5 d:2015-03-04T15:14:40Z
 ```
 
-* Insert numeric value '20.5' for metric 'disk_used_percent', entity 'server001', and two tags, 'mount_point' and 'disk_name'. The value will be inserted with the current server time since the date is not specified in the command.
+* Insert the numeric value '20.5' for the metric 'disk_used_percent' from the entity 'server001' and the two tags 'mount_point' and 'disk_name'. The value will be inserted with the current server time since the date is not specified in the command.
 
 ```ls
 series e:server001 m:disk_used_percent=20.5 t:mount_point=/ t:disk_name=/sda1
@@ -106,13 +106,13 @@ series e:server001 m:disk_used_percent=20.5 t:mount_point=/ t:disk_name=/sda1
 series e:server001 m:disk_used_percent=20.5 m:disk_size_mb=10240 t:mount_point=/ t:disk_name=/sda1
 ```
 
-* Insert numeric value '24.4' and text value 'Provisional' (annotation) for metric 'temperature', entity 'sensor-1'.
+* Insert the numeric value '24.4' and the text value 'Provisional' (annotation) for the metric 'temperature' from the entity 'sensor-1'.
 
 ```ls
 series d:2016-10-13T08:15:00Z e:sensor-1 m:temperature=24.4 x:temperature="Provisional"
 ```
 
-* Insert text value 'Shutdown by adm-user, RFC-5434' for metric 'status', entity 'sensor-1'.
+* Insert the text value 'Shutdown by adm-user, RFC-5434' for the metric 'status', from the entity 'sensor-1'.
 
 ```ls
 series d:2016-10-13T10:30:00Z e:sensor-1 x:status="Shutdown by adm-user, RFC-5434"
@@ -124,7 +124,7 @@ series d:2016-10-13T10:30:00Z e:sensor-1 x:status="Shutdown by adm-user, RFC-543
 series d:2016-10-13T10:30:00Z e:sensor-1 x:status="Shutdown by adm-user, RFC-5434" a:true
 ```
 
-* Insert 'NaN' (Not-a-Number) for metric 'temperature', entity 'sensor-1'
+* Insert 'NaN' (Not-a-Number) for the metric 'temperature' from the entity 'sensor-1'
 
 ```ls
 series d:2016-10-13T08:45:00Z e:sensor-1 m:temperature=NaN
@@ -132,18 +132,18 @@ series d:2016-10-13T08:45:00Z e:sensor-1 m:temperature=NaN
 
 ## Number Representation
 
-* The numeric value can be a real number or `NaN` (Not a Number).
-* The string representation of an inserted number consists of an optional sign, '+' ('\u002B') or '-' ('\u002D'), followed by a sequence of zero or more decimal digits ("the integer"), optionally followed by a fraction, optionally followed by an exponent.
+* A numeric value can be a real number or `NaN` (Not a Number).
+* The string representation of an inserted number can consist of additional optional signs, '+' ('\u002B') or '-' ('\u002D'), followed by a sequence of zero or more decimal digits ("the integer"), optionally followed by a fraction, optionally followed by an exponent.
 * The exponent consists of the character 'e' ('\u0065') or 'E' ('\u0045') followed by an optional sign, '+' ('\u002B') or '-' ('\u002D'), followed by one or more decimal digits. The value of the exponent must lie between -2147483647 and 2147483647, and is inclusive.
 * The fraction consists of a decimal point followed by zero or more decimal digits. The string must contain at least one digit in either the integer or the fraction.
 * The number formed by the sign, the integer, and the fraction is referred to as the [**significand**](https://en.wikipedia.org/wiki/Significand).
-* The **significand** value stripped from trailing zeros should be within the Long.MAX_VALUE `9223372036854775807` the and Long.MIN_VALUE  `-9223372036854775808` (19 digits). Otherwise the database will throw an **llegalArgumentException: BigDecimal significand overflows the long type** for decimal metrics or round the value for non-decimal metrics. For example, significand for `1.1212121212121212121212121212121212121212121` contains 44 digits and will be rounded to `1.121212121212121212` if inserted for a non-decimal metric.
+* The **significand** value, stripped of trailing zeros, should be within the Long.MAX_VALUE `9223372036854775807` and the Long.MIN_VALUE  `-9223372036854775808` (19 digits). Otherwise the database will throw an **llegalArgumentException: BigDecimal significand overflows the long type** for decimal metrics or round the value for non-decimal metrics. For example, significand for `1.1212121212121212121212121212121212121212121` contains 44 digits and will be rounded to `1.121212121212121212` if inserted for a non-decimal metric.
 
 ## Series Tags, Text Value, Messages
 
-The difference between series tags and text values inserted with the `x:` field is that tag names/values are converted to unique identifiers when stored.
+Text values inserted with the `x:` field tag are converted to unique identifiers when stored, which differentiates them from series tags inserted with the `m:` field tag
 
-Series tags are part of each series composite primary key, whereas the text value is not.
+Series tags are part of each series' composite primary key, whereas text values are not.
 
 Since the total number of unique tag value identifiers is [limited](README.md#schema) to `16,777,215`, series tag values are not well suited for values with high cardinality such as random values or continuously incrementing values (time, counters).
 
@@ -183,7 +183,7 @@ WHERE metric IN ('temperature', 'status') AND datetime >= '2016-10-13T08:00:00Z'
 
 The `append` flag applies to text values specified with the `x:` field.
 
-If the append flag is set to `true`, ATSD checks the previous text value for the same timestamp. If the previous value is found, the new value is appended at the end using `;\n` (semi-colon followed by line feed) as a separator.
+If the append flag is set to `true`, ATSD checks the previous text value for the same timestamp. If the previous value is found, the new value is appended to the end using `;\n` (semi-colon followed by line feed) as a separator.
 
 In order to prevent **duplicate** values, the database checks the existing value for duplicates by splitting the stored value into a string array and discarding the new value if it is equal to one of the elements in the array.
 
@@ -203,9 +203,9 @@ Restart
 
 [Versioning](http://axibase.com/products/axibase-time-series-database/data-model/versioning/) enables tracking of time-series value changes for the purpose of establishing an audit trail and traceable data reconciliation.
 
-Versioning is disabled by default. It can be enabled for particular metrics by applying the Versioning check box on the Metric Editor page.
+Versioning is disabled by default. It can be enabled for particular metrics by checking the Versioning box on the Metric Editor page.
 
-To insert versioning fields use reserved tags:
+To insert versioning fields, use reserved tags:
 
 * `$version_source`
 * `$version_status`
@@ -214,4 +214,4 @@ To insert versioning fields use reserved tags:
 series s:1425482080 e:e-vers m:m-vers=13 t:$version_status=OK t:$version_source=collector-1
 ```
 
-If the metrics are versioned,  `$version_source` and `$version_status` tags will be ignored as regular series tags and instead will be converted to corresponding versioning tags.
+If the metrics are versioned, the `$version_source` and `$version_status` tags will be converted to the corresponding versioning tags.

--- a/api/network/series.md
+++ b/api/network/series.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-Use the `series`command to insert a timestamped value (number or text) into a specified time series, uniquely identified by a composite primary key consisting of an entity, metric, and optional `key=value` tag(s).
+Use the `series` command to insert a timestamped value (number or text) into a specified time series, uniquely identified by a composite primary key consisting of an entity, metric, and optional `key=value` tag(s).
 
 ## Syntax
 
@@ -133,7 +133,7 @@ series d:2016-10-13T08:45:00Z e:sensor-1 m:temperature=NaN
 ## Number Representation
 
 * A numeric value can be a real number or `NaN` (Not a Number).
-* The string representation of an inserted number can consist of additional optional signs, '+' ('\u002B') or '-' ('\u002D'), followed by a sequence of zero or more decimal digits ("the integer"), optionally followed by a fraction, optionally followed by an exponent.
+* The string representation of a real number can consist of optional signs, '+' ('\u002B') or '-' ('\u002D'), followed by a sequence of zero or more decimal digits ("the integer"), optionally followed by a fraction, optionally followed by an exponent.
 * The exponent consists of the character 'e' ('\u0065') or 'E' ('\u0045') followed by an optional sign, '+' ('\u002B') or '-' ('\u002D'), followed by one or more decimal digits. The value of the exponent must lie between -2147483647 and 2147483647, and is inclusive.
 * The fraction consists of a decimal point followed by zero or more decimal digits. The string must contain at least one digit in either the integer or the fraction.
 * The number formed by the sign, the integer, and the fraction is referred to as the [**significand**](https://en.wikipedia.org/wiki/Significand).
@@ -141,20 +141,20 @@ series d:2016-10-13T08:45:00Z e:sensor-1 m:temperature=NaN
 
 ## Series Tags, Text Value, Messages
 
-Text values inserted with the `x:` field tag are converted to unique identifiers when stored, which differentiates them from series tags inserted with the `m:` field tag
+Text inserted with the `x:` field annotates the accompanying numeric value and is not part of the series composite key.
 
-Series tags are part of each series' composite primary key, whereas text values are not.
+Series tags, on the other hand, are part of each series' composite primary key.
 
-Since the total number of unique tag value identifiers is [limited](README.md#schema) to `16,777,215`, series tag values are not well suited for values with high cardinality such as random values or continuously incrementing values (time, counters).
+Since the total number of unique tag value identifiers is [limited](README.md#schema) to `16,777,215`, series tags are not recommended for high cardinality fields such as random values or continuously incrementing values (time, counters).
 
-A text value, on the other hand, is stored `as is`, without converting it to an identifier. A text value can be used to annotate a numeric observation without changing the series' primary key.
+A text value, on the other hand, is stored as an annotation, without converting it to an identifier.
 
 ```ls
 series d:2016-10-13T08:00:00Z e:sensor-1 m:temperature=20.3
 series d:2016-10-13T08:15:00Z e:sensor-1 m:temperature=24.4 x:temperature="Provisional"
 ```
 
-In this example, the temperature reading at `2016-10-13T08:15:00Z` is characterized as `Provisional`.
+In this example, the temperature reading at `2016-10-13T08:15:00Z` is annotated as `Provisional`.
 
 A text value can also be used to record observations for series that contain only text values, in which case their numeric values are set to `NaN`.
 


### PR DESCRIPTION
Please double check the following changes:

* Line 34, "If the numeric observation was not specified..." Ambiguous meaning, what is the numeric observation?

* Line 140, "The significand stripped OF/FROM trailing zeros..." Original text was FROM which implies the number was derived from trailing zeros and OF implies the number's trailing zeros were stripped. I was unable to be 100% it was either, but it seems more likely that OF is the correct word choice.

* Line 144, it seems the author is referring to the difference between the `x:` and `m:` field tags described above, but refers to the latter by a different name.

* Line 208, "To insert versioning fields, use reserved tags..." I added a comma here but again, the meaning is somewhat ambiguous. Are reserved tags used to insert versioning fields? In that case it should read, "To insert versioning fields USING reserved tags...." but if the solution to the question "How do I insert versioning fields?" is "Use reserved tags" than my edit is correct.