### PR TITLE
changed `retentionInterval` field to `retentionDays`

### DIFF
--- a/api/meta/entity/metrics.md
+++ b/api/meta/entity/metrics.md
@@ -65,7 +65,7 @@ curl https://atsd_host:8443/api/v1/entities/nurswgvml007/metrics?limit=2 \
         "dataType": "FLOAT",
         "persistent": true,
         "timePrecision": "MILLISECONDS",
-        "retentionInterval": 0,
+        "retentionDays": 0,
         "invalidAction": "NONE",
         "lastInsertDate": "2015-09-04T16:10:21.000Z"
     },
@@ -75,7 +75,7 @@ curl https://atsd_host:8443/api/v1/entities/nurswgvml007/metrics?limit=2 \
         "dataType": "FLOAT",
         "persistent": true,
         "timePrecision": "MILLISECONDS",
-        "retentionInterval": 0,
+        "retentionDays": 0,
         "invalidAction": "NONE",
         "lastInsertDate": "2015-09-04T16:10:21.000Z"
     }

--- a/api/meta/metric/create-or-replace.md
+++ b/api/meta/metric/create-or-replace.md
@@ -55,7 +55,7 @@ PUT https://atsd_host:8443/api/v1/metrics/my-metric
   "dataType": "DOUBLE",
   "interpolate": "PREVIOUS",
   "timePrecision": "MILLISECONDS",
-  "retentionInterval": 0
+  "retentionDays": 0
 }
 ```
 
@@ -66,7 +66,7 @@ curl https://atsd_host:8443/api/v1/metrics/my-metric \
   --insecure --verbose --user {username}:{password} \
   --header "Content-Type: application/json" \
   --request PUT \
-  --data '{"enabled":true,"persistent":true,"dataType":"DOUBLE","interpolate": "PREVIOUS","timePrecision":"MILLISECONDS","retentionInterval":0}'
+  --data '{"enabled":true,"persistent":true,"dataType":"DOUBLE","interpolate": "PREVIOUS","timePrecision":"MILLISECONDS","retentionDays":0}'
 ```
 
 ### Response

--- a/api/meta/metric/examples/fetch-metrics-by-limit-parameter.md
+++ b/api/meta/metric/examples/fetch-metrics-by-limit-parameter.md
@@ -14,7 +14,7 @@ https://atsd_host:8443/api/v1/metrics?limit=3
       "dataType":"FLOAT",
       "persistent":true,
       "timePrecision":"MILLISECONDS",
-      "retentionInterval":0,
+      "retentionDays":0,
       "invalidAction":"NONE",
       "lastInsertTime":1463129522969,
       "versioned":false
@@ -26,7 +26,7 @@ https://atsd_host:8443/api/v1/metrics?limit=3
       "description":"it is description",
       "persistent":true,
       "timePrecision":"MILLISECONDS",
-      "retentionInterval":2,
+      "retentionDays":2,
       "minValue":21.0,
       "maxValue":125.0,
       "invalidAction":"RAISE_ERROR",
@@ -40,7 +40,7 @@ https://atsd_host:8443/api/v1/metrics?limit=3
       "dataType":"FLOAT",
       "persistent":true,
       "timePrecision":"MILLISECONDS",
-      "retentionInterval":0,
+      "retentionDays":0,
       "invalidAction":"NONE",
       "lastInsertTime":1463129525000,
       "versioned":false

--- a/api/meta/metric/examples/list-active-metrics.md
+++ b/api/meta/metric/examples/list-active-metrics.md
@@ -15,7 +15,7 @@ GET https://atsd_host:8443/api/v1/metrics?active=true&timeFormat=iso
       "dataType":"FLOAT",
       "persistent":true,
       "timePrecision":"MILLISECONDS",
-      "retentionInterval":0,
+      "retentionDays":0,
       "invalidAction":"NONE",
       "lastInsertTime":"2016-05-19T09:18:49.000Z",
       "versioned":false
@@ -26,7 +26,7 @@ GET https://atsd_host:8443/api/v1/metrics?active=true&timeFormat=iso
       "dataType":"FLOAT",
       "persistent":true,
       "timePrecision":"MILLISECONDS",
-      "retentionInterval":0,
+      "retentionDays":0,
       "invalidAction":"NONE",
       "lastInsertTime":"2016-05-19T09:18:49.000Z",
       "versioned":false
@@ -37,7 +37,7 @@ GET https://atsd_host:8443/api/v1/metrics?active=true&timeFormat=iso
       "dataType":"FLOAT",
       "persistent":true,
       "timePrecision":"MILLISECONDS",
-      "retentionInterval":0,
+      "retentionDays":0,
       "invalidAction":"NONE",
       "lastInsertTime":"2016-05-19T09:18:49.000Z",
       "versioned":false

--- a/api/meta/metric/examples/list-metrics-by-maxinsertdate.md
+++ b/api/meta/metric/examples/list-metrics-by-maxinsertdate.md
@@ -16,7 +16,7 @@ GET https://atsd_host:8443/api/v1/metrics?maxInsertDate=2016-05-19T08:13:40.000Z
       "dataType":"FLOAT",
       "persistent":true,
       "timePrecision":"MILLISECONDS",
-      "retentionInterval":0,
+      "retentionDays":0,
       "invalidAction":"NONE",
       "lastInsertDate":"2016-05-18T22:50:00.000Z",
       "versioned":false
@@ -27,7 +27,7 @@ GET https://atsd_host:8443/api/v1/metrics?maxInsertDate=2016-05-19T08:13:40.000Z
       "dataType":"FLOAT",
       "persistent":true,
       "timePrecision":"MILLISECONDS",
-      "retentionInterval":0,
+      "retentionDays":0,
       "invalidAction":"NONE",
       "lastInsertDate":"2016-05-18T22:50:00.000Z",
       "versioned":false
@@ -38,7 +38,7 @@ GET https://atsd_host:8443/api/v1/metrics?maxInsertDate=2016-05-19T08:13:40.000Z
       "dataType":"FLOAT",
       "persistent":true,
       "timePrecision":"MILLISECONDS",
-      "retentionInterval":0,
+      "retentionDays":0,
       "invalidAction":"NONE",
       "lastInsertDate":"2016-05-05T05:50:18.312Z",
       "versioned":false

--- a/api/meta/metric/examples/list-metrics-by-mininsertdate.md
+++ b/api/meta/metric/examples/list-metrics-by-mininsertdate.md
@@ -16,7 +16,7 @@ GET https://atsd_host:8443/api/v1/metrics?minInsertDate=2016-05-18T22:13:40.000Z
       "dataType":"FLOAT",
       "persistent":true,
       "timePrecision":"MILLISECONDS",
-      "retentionInterval":0,
+      "retentionDays":0,
       "invalidAction":"NONE",
       "lastInsertDate":"2016-05-18T22:50:00.000Z",
       "versioned":false
@@ -27,7 +27,7 @@ GET https://atsd_host:8443/api/v1/metrics?minInsertDate=2016-05-18T22:13:40.000Z
       "dataType":"FLOAT",
       "persistent":true,
       "timePrecision":"MILLISECONDS",
-      "retentionInterval":0,
+      "retentionDays":0,
       "invalidAction":"NONE",
       "lastInsertDate":"2016-05-19T03:50:00.000Z",
       "versioned":false
@@ -38,7 +38,7 @@ GET https://atsd_host:8443/api/v1/metrics?minInsertDate=2016-05-18T22:13:40.000Z
       "dataType":"FLOAT",
       "persistent":true,
       "timePrecision":"MILLISECONDS",
-      "retentionInterval":0,
+      "retentionDays":0,
       "invalidAction":"NONE",
       "lastInsertDate":"2016-05-19T10:07:54.749Z",
       "versioned":false

--- a/api/meta/metric/examples/list-metrics-by-name-and-tag.md
+++ b/api/meta/metric/examples/list-metrics-by-name-and-tag.md
@@ -27,7 +27,7 @@ name LIKE 'nmon*' and tags.table LIKE '*CPU*'
             "table": "CPU Detail"
         },
         "timePrecision": "MILLISECONDS",
-        "retentionInterval": 0,
+        "retentionDays": 0,
         "invalidAction": "NONE",
         "lastInsertDate": "2016-05-19T10:38:26.731Z",
         "versioned": false
@@ -41,7 +41,7 @@ name LIKE 'nmon*' and tags.table LIKE '*CPU*'
             "table": "CPU Detail"
         },
         "timePrecision": "MILLISECONDS",
-        "retentionInterval": 0,
+        "retentionDays": 0,
         "invalidAction": "NONE",
         "lastInsertDate": "2016-05-19T10:38:26.731Z",
         "versioned": false

--- a/api/meta/metric/examples/list-metrics-by-name.md
+++ b/api/meta/metric/examples/list-metrics-by-name.md
@@ -27,7 +27,7 @@ expression=name like '*disk*'
         "persistent": true,
         "tags": {},
         "timePrecision": "MILLISECONDS",
-        "retentionInterval": 0,
+        "retentionDays": 0,
         "invalidAction": "NONE",
         "lastInsertDate": "2016-05-18T00:35:12.000Z",
         "versioned": false
@@ -39,7 +39,7 @@ expression=name like '*disk*'
         "persistent": true,
         "tags": {},
         "timePrecision": "MILLISECONDS",
-        "retentionInterval": 0,
+        "retentionDays": 0,
         "invalidAction": "NONE",
         "lastInsertDate": "2016-05-18T00:35:12.000Z",
         "versioned": false
@@ -51,7 +51,7 @@ expression=name like '*disk*'
         "persistent": true,
         "tags": {},
         "timePrecision": "MILLISECONDS",
-        "retentionInterval": 0,
+        "retentionDays": 0,
         "invalidAction": "NONE",
         "lastInsertDate": "2016-05-18T00:35:12.000Z",
         "versioned": false

--- a/api/meta/metric/examples/list-metrics-with-tag-table.md
+++ b/api/meta/metric/examples/list-metrics-with-tag-table.md
@@ -26,7 +26,7 @@ tags.table != ''
             "table": "axibase-collector"
         },
         "timePrecision": "MILLISECONDS",
-        "retentionInterval": 0,
+        "retentionDays": 0,
         "invalidAction": "NONE",
         "lastInsertDate": "2016-05-19T10:38:26.731Z",
         "versioned": false
@@ -40,7 +40,7 @@ tags.table != ''
             "table": "axibase-collector"
         },
         "timePrecision": "MILLISECONDS",
-        "retentionInterval": 0,
+        "retentionDays": 0,
         "invalidAction": "NONE",
         "lastInsertDate": "2016-05-19T10:38:26.731Z",
         "versioned": false

--- a/api/meta/metric/get.md
+++ b/api/meta/metric/get.md
@@ -56,7 +56,7 @@ curl https://atsd_host:8443/api/v1/metrics/cpu_busy \
   "persistent": true,
   "tags": {},
   "timePrecision": "MILLISECONDS",
-  "retentionInterval": 0,
+  "retentionDays": 0,
   "invalidAction": "NONE",
   "lastInsertDate": "2016-10-05T12:10:26.000Z",
   "versioned": false


### PR DESCRIPTION
`retentionInterval` field was renamed to `retentionDays` in revision 14543 (2016-10-28), but the examples in documentation are still using the old name.