### PR TITLE
ssl-configure.md 

### DIFF
--- a/administration/ssl-configure.md
+++ b/administration/ssl-configure.md
@@ -1,25 +1,33 @@
-# Installing self-signed Certificate Files into ATSD
+# Installing Self-signed SSL Certificate
 
-## Remove old ATSD keystore
+## Overview
+
+The default certificate installed in ATSD is generated for DNS name 'atsd'. This document describes the process of creating and installing a self-signed SSL certificate to match the actual DNS name used by clients when accessing ATSD user interface and HTTP API. 
+
+As with all self-signed certificates, the new certificate will still cause a security exception in user browsers and will require passing `-k/--insecure` parameter when connecting to ATSD using `curl` and similar tools in order to skip certificate validation.
+
+## Remove Keystore File
+
+Delete the current Java keystore file from the configuration directory.
 
 ```bash
 rm /opt/atsd/atsd/conf/server.keystore
 ```
-## Create keystore, keypair and certificate
+## Generate Certificate
 
-Follow the prompts to create certificate.
- 
-> Note since self-signed certificates mean the lack of the root CA signature only `first and last name` require to be specified.
+Generate a new self-signed certificate using the [`keytool`](https://docs.oracle.com/javase/8/docs/technotes/tools/unix/keytool.html) utility.
 
 ```bash
-keytool -genkeypair -keystore /opt/atsd/atsd/conf/server.keystore -keyalg RSA -keysize 2048 -validity 365
+keytool -genkeypair -keystore /opt/atsd/atsd/conf/server.keystore -keyalg RSA -keysize 2048 -validity 3650
 ```
+
+The self-signed certificate requires only `first and last name` question to be answered. It should be set to the DNS name used by clients when connecting to the ATSD server, such as `atsd.customer_domain.com` in the example below. The remaining fields are optional.
   
 ```bash
 Enter keystore password: NEW_PASS  
 Re-enter new password: NEW_PASS
 What is your first and last name?
-  [Unknown]:  ATSD_HOSTNAME
+  [Unknown]:  atsd.customer_domain.com
 What is the name of your organizational unit?
   [Unknown]:  
 What is the name of your organization?
@@ -30,26 +38,28 @@ What is the name of your State or Province?
   [Unknown]:  
 What is the two-letter country code for this unit?
   [Unknown]:  
-Is CN=ATSD_HOSTNAME, OU=Unknown, O=Unknown, L=Unknown, ST=Unknown, C=Unknown correct?
+Is CN=atsd.customer_domain.com, OU=Unknown, O=Unknown, L=Unknown, ST=Unknown, C=Unknown correct?
   [no]:  yes
 
 Enter key password for <mykey>
 	(RETURN if same as keystore password): <press RETURN>
 ```
 
-## Update passwords in the server.properties file
+## Update Keystore Passwords
 
-Replace default password at `https.keyStorePassword` and `https.keyManagerPassword` with `NEW_PASS` in /opt/atsd/atsd/conf/server.properties file.
+Open `/opt/atsd/atsd/conf/server.properties` file.
 
 ```bash
 nano /opt/atsd/atsd/conf/server.properties
 ```
 
-```bash
+Specify the new password in `https.keyStorePassword` and `https.keyManagerPassword` settings. Leave `https.trustStorePassword` blank.
+
+```properties
 ...
 https.keyStorePassword=NEW_PASS
 https.keyManagerPassword=NEW_PASS
-...
+https.trustStorePassword=
 ```
 
 ## Restart ATSD
@@ -58,3 +68,9 @@ https.keyManagerPassword=NEW_PASS
 /opt/atsd/atsd/bin/stop-atsd.sh
 /opt/atsd/atsd/bin/start-atsd.sh
 ```
+
+## Verify Certificate
+
+Login into ATSD by entering its DNS name in the browser address bar.
+
+Review the new certificate and check its validity date which is set to 10 years from now.

--- a/administration/ssl-configure.md
+++ b/administration/ssl-configure.md
@@ -1,0 +1,70 @@
+# Installing CA-signed Certificate Files into ATSD
+
+## Create certificate
+
+Replace `example.key`, `example.crt` with appropriate names of private key file and CA-certificate file to be created. Follow the prompts to create Distinguished Name:
+
+```bash
+openssl req -x509 -newkey rsa:2048 -keyout example.key -out example.crt -days 365 
+```
+
+```bash
+Enter PEM pass phrase: PRIVATE_KEY_PASS
+Verifying - Enter PEM pass phrase: PRIVATE_KEY_PASS
+
+Country Name (2 letter code) [AU]:US
+State or Province Name (full name) [Some-State]:CA
+Locality Name (eg, city) []:Cupertino
+Organization Name (eg, company) [Internet Widgits Pty Ltd]:Axibase Corporation
+Organizational Unit Name (eg, section) []:Software Group
+Common Name (e.g. server FQDN or YOUR name) []:atsd
+Email Address []:example@example.com
+```
+
+## Create keystore with custom password
+
+Replace `example.key`, `example.crt` with appropriate names of private key file and CA-certificate file created early, replace `example.pkcs12`, `example` with appropriate names of keystore file and alias to be created.
+
+```bash
+openssl pkcs12 -export -inkey example.key -in example.crt -out example.pkcs12 -name example
+```
+
+```bash
+Enter pass phrase for example.key: PRIVATE_KEY_PASS 
+Enter Export Password: EXPORT_KEYSTORE_PASS 
+Verifying - Enter Export Password: EXPORT_KEYSTORE_PASS
+```
+## Import certificate into the keystore
+
+Remove old ATSD keystore.
+
+```bash
+rm /opt/atsd/atsd/conf/server.keystore
+```
+
+Create new keystore at `/opt/atsd/atsd/conf/`and import PKCS12 keystore created at previous step.
+
+```bash
+keytool -importkeystore -srckeystore example.pkcs12 -srcstoretype PKCS12 -destkeystore /opt/atsd/atsd/conf/server.keystore -alias example
+```
+
+```bash
+Enter destination keystore password: NEW_KEYSTORE_PASS
+Re-enter new password: NEW_KEYSTORE_PASS
+Enter source keystore password: EXPORT_KEYSTORE_PASS
+```
+## Update passwords in the server.properties file
+
+Replace `NEW_KEYSTORE_PASS`, `EXPORT_KEYSTORE_PASS` with appropriate passwords of server.keystore and *.pkcs12 keystores.
+
+```bash
+sed -i "s,^https.keyStorePassword=.*,https.keyStorePassword=NEW_KEYSTORE_PASS,g" /opt/atsd/atsd/conf/server.properties; \
+sed -i "s,^https.keyManagerPassword=.*,https.keyManagerPassword=EXPORT_KEYSTORE_PASS,g" /opt/atsd/atsd/conf/server.properties
+```
+
+## Restart ATSD
+
+```bash
+/opt/atsd/atsd/bin/stop-atsd.sh
+/opt/atsd/atsd/bin/start-atsd.sh
+```

--- a/administration/ssl-configure.md
+++ b/administration/ssl-configure.md
@@ -1,65 +1,50 @@
 # Installing CA-signed Certificate Files into ATSD
 
-## Create certificate
-
-Replace `example.key`, `example.crt` with appropriate names of private key file and CA-certificate file to be created. Follow the prompts to create Distinguished Name:
-
-```bash
-openssl req -x509 -newkey rsa:2048 -keyout example.key -out example.crt -days 365 
-```
-
-```bash
-Enter PEM pass phrase: PRIVATE_KEY_PASS
-Verifying - Enter PEM pass phrase: PRIVATE_KEY_PASS
-
-Country Name (2 letter code) [AU]:US
-State or Province Name (full name) [Some-State]:CA
-Locality Name (eg, city) []:Cupertino
-Organization Name (eg, company) [Internet Widgits Pty Ltd]:Axibase Corporation
-Organizational Unit Name (eg, section) []:Software Group
-Common Name (e.g. server FQDN or YOUR name) []:atsd
-Email Address []:example@example.com
-```
-
-## Create keystore with custom password
-
-Replace `example.key`, `example.crt` with appropriate names of private key file and CA-certificate file created early, replace `example.pkcs12`, `example` with appropriate names of keystore file and alias to be created.
-
-```bash
-openssl pkcs12 -export -inkey example.key -in example.crt -out example.pkcs12 -name example
-```
-
-```bash
-Enter pass phrase for example.key: PRIVATE_KEY_PASS 
-Enter Export Password: EXPORT_KEYSTORE_PASS 
-Verifying - Enter Export Password: EXPORT_KEYSTORE_PASS
-```
-## Import certificate into the keystore
-
-Remove old ATSD keystore.
+## Remove old ATSD keystore
 
 ```bash
 rm /opt/atsd/atsd/conf/server.keystore
 ```
+## Create keystore, keypair and certificate
 
-Create new keystore at `/opt/atsd/atsd/conf/`and import PKCS12 keystore created at previous step.
+Follow the prompts to create certificate.
+ 
+> Note since self-signed certificates mean the lack of the root CA signature only `first and last name` must be specified.
 
 ```bash
-keytool -importkeystore -srckeystore example.pkcs12 -srcstoretype PKCS12 -destkeystore /opt/atsd/atsd/conf/server.keystore -alias example
+keytool -genkeypair -keystore /opt/atsd/atsd/conf/server.keystore -alias atsd -keyalg RSA -keysize 2048 -validity 365
 ```
-
+  
 ```bash
-Enter destination keystore password: NEW_KEYSTORE_PASS
+Enter keystore password: NEW_KEYSTORE_PASS  
 Re-enter new password: NEW_KEYSTORE_PASS
-Enter source keystore password: EXPORT_KEYSTORE_PASS
+What is your first and last name?
+  [Unknown]:  localhost
+What is the name of your organizational unit?
+  [Unknown]:  
+What is the name of your organization?
+  [Unknown]:  
+What is the name of your City or Locality?
+  [Unknown]:  
+What is the name of your State or Province?
+  [Unknown]:  
+What is the two-letter country code for this unit?
+  [Unknown]:  
+Is CN=localhost, OU=Unknown, O=Unknown, L=Unknown, ST=Unknown, C=Unknown correct?
+  [no]:  yes
+
+Enter key password for <atsd>
+	(RETURN if same as keystore password): NEW_ALIAS_PASS
+Re-enter new password: NEW_ALIAS_PASS
 ```
+
 ## Update passwords in the server.properties file
 
-Replace `NEW_KEYSTORE_PASS`, `EXPORT_KEYSTORE_PASS` with appropriate passwords of server.keystore and *.pkcs12 keystores.
+Replace `NEW_KEYSTORE_PASS` server.keystore.
 
 ```bash
 sed -i "s,^https.keyStorePassword=.*,https.keyStorePassword=NEW_KEYSTORE_PASS,g" /opt/atsd/atsd/conf/server.properties; \
-sed -i "s,^https.keyManagerPassword=.*,https.keyManagerPassword=EXPORT_KEYSTORE_PASS,g" /opt/atsd/atsd/conf/server.properties
+sed -i "s,^https.keyManagerPassword=.*,https.keyManagerPassword=NEW_ALIAS_PASS,g" /opt/atsd/atsd/conf/server.properties
 ```
 
 ## Restart ATSD

--- a/administration/ssl-configure.md
+++ b/administration/ssl-configure.md
@@ -1,4 +1,4 @@
-# Installing CA-signed Certificate Files into ATSD
+# Installing self-signed Certificate Files into ATSD
 
 ## Remove old ATSD keystore
 

--- a/administration/ssl-configure.md
+++ b/administration/ssl-configure.md
@@ -9,17 +9,17 @@ rm /opt/atsd/atsd/conf/server.keystore
 
 Follow the prompts to create certificate.
  
-> Note since self-signed certificates mean the lack of the root CA signature only `first and last name` must be specified.
+> Note since self-signed certificates mean the lack of the root CA signature only `first and last name` require to be specified.
 
 ```bash
-keytool -genkeypair -keystore /opt/atsd/atsd/conf/server.keystore -alias atsd -keyalg RSA -keysize 2048 -validity 365
+keytool -genkeypair -keystore /opt/atsd/atsd/conf/server.keystore -keyalg RSA -keysize 2048 -validity 365
 ```
   
 ```bash
-Enter keystore password: NEW_KEYSTORE_PASS  
-Re-enter new password: NEW_KEYSTORE_PASS
+Enter keystore password: NEW_PASS  
+Re-enter new password: NEW_PASS
 What is your first and last name?
-  [Unknown]:  localhost
+  [Unknown]:  ATSD_HOSTNAME
 What is the name of your organizational unit?
   [Unknown]:  
 What is the name of your organization?
@@ -30,21 +30,26 @@ What is the name of your State or Province?
   [Unknown]:  
 What is the two-letter country code for this unit?
   [Unknown]:  
-Is CN=localhost, OU=Unknown, O=Unknown, L=Unknown, ST=Unknown, C=Unknown correct?
+Is CN=ATSD_HOSTNAME, OU=Unknown, O=Unknown, L=Unknown, ST=Unknown, C=Unknown correct?
   [no]:  yes
 
-Enter key password for <atsd>
-	(RETURN if same as keystore password): NEW_ALIAS_PASS
-Re-enter new password: NEW_ALIAS_PASS
+Enter key password for <mykey>
+	(RETURN if same as keystore password): <press RETURN>
 ```
 
 ## Update passwords in the server.properties file
 
-Replace `NEW_KEYSTORE_PASS` server.keystore.
+Replace default password at `https.keyStorePassword` and `https.keyManagerPassword` with `NEW_PASS` in /opt/atsd/atsd/conf/server.properties file.
 
 ```bash
-sed -i "s,^https.keyStorePassword=.*,https.keyStorePassword=NEW_KEYSTORE_PASS,g" /opt/atsd/atsd/conf/server.properties; \
-sed -i "s,^https.keyManagerPassword=.*,https.keyManagerPassword=NEW_ALIAS_PASS,g" /opt/atsd/atsd/conf/server.properties
+nano /opt/atsd/atsd/conf/server.properties
+```
+
+```bash
+...
+https.keyStorePassword=NEW_PASS
+https.keyManagerPassword=NEW_PASS
+...
 ```
 
 ## Restart ATSD


### PR DESCRIPTION
Keystore can be created only after the certificate was created.