### PR TITLE
fixed time condition

### DIFF
--- a/rule-engine/condition.md
+++ b/rule-engine/condition.md
@@ -128,5 +128,5 @@ Alternatively, the metric's last value can be retrieved with the `db_last` and `
 The condition is `true` if the average exceeds `90` at any time or if the average exceeds `50` during the working hours (between `08:00:00` and `17:59:59`).
 
 ```javascript
-  avg() > 90 || avg() > 50 && now.hourOfDay() BETWEEN 8 AND 17
+  avg() > 90 || avg() > 50 && now.getHourOfDay() BETWEEN 8 AND 17
 ```


### PR DESCRIPTION
`hourOfDay()` returns `org.joda.time.DateTime$Property` object, while `getHourOfDay()` returns `int`