### PR TITLE
Tcollector and scollector instructions update

### DIFF
--- a/integration/scollector/scollector-startup.md
+++ b/integration/scollector/scollector-startup.md
@@ -1,50 +1,44 @@
-# scollector Startup
+# scollector
 
 ## Linux
 
 ### Script Installation
 
-```bash
-mkdir scollector
-cd scollector
-wget https://github.com/bosun-monitor/bosun/releases/download/0.6.0-beta1/scollector-linux-amd64
-# replace usr and pwd with actual credentials for a collector account
-echo 'Host = "http://username:password@10.102.0.6:8088/"' > scollector.toml
-chmod 700 scollector-linux-amd64
-nohup ./scollector-linux-amd64 &
-```
+ ```sh
+ mkdir scollector
+ cd scollector
+ wget https://github.com/bosun-monitor/bosun/releases/download/0.6.0-beta1/scollector-linux-amd64
+ # replace username and password with actual credentials
+ echo 'Host = "http://username:password@atsd_hostname:8088/"' > scollector.toml
+ chmod 700 scollector-linux-amd64
+ nohup ./scollector-linux-amd64 &
+ ```
 
 ### Manual Installation
 
 Download the binary file from: [http://bosun.org/scollector/](http://bosun.org/scollector/).
 
-You can find the official configuration guides here: [http://godoc.org/bosun.org/cmd/scollector](http://godoc.org/bosun.org/cmd/scollector).
-
-Alternatively, you can use the "scollector Cookbook" to install scollector on your machines: [https://supermarket.chef.io/cookbooks/scollector](https://supermarket.chef.io/cookbooks/scollector).
-
-Create the `scollector.toml` Configuration File:
-
 Navigate to the directory with binary files and create the `scollector.toml` file.
-
-> Make sure the name of the file is `scollector.toml`.
 
 Add `Host` setting to `scollector.toml`:
 
-```toml
-Host = "http://atsd_username:atsd_password@atsd_server:8088/"
-```
+ ```toml
+ Host = "http://username:password@atsd_hostname:8088/"
+ ```
 
-> If you installed a CA-signed SSL certificate into ATSD, you can change the above url to the secure https endpoint.
+scollector does not support untrusted SSL certificates. If you installed a CA-signed SSL certificate into ATSD, you can change the above setting to connect to the secure https endpoint.
 
-> At this time scollector does not support communication with ATSD if it’s SSL certificate is self-signed.
+ ```toml
+ Host = "https://username:password@atsd_hostname:8443/"
+ ```
 
-### Auto-start scollector under sudo user
+### Auto-start under sudo user
 
-> The init scripts in this section for systems without systemd do not support daemon stopping and do not check if service is already running
+> Note that `init` scripts for systems without `systemd` do not support daemon stopping and do not check if service is already running.
 
 #### Ubuntu 14.04
 
-Create `/etc/init.d/scollector` file from scollector installation directory and make it executable
+Create `/etc/init.d/scollector` file by running the following command in the scollector installation directory.
 
 ```sh
 sudo cat <<EOF > /etc/init.d/scollector
@@ -59,24 +53,29 @@ sudo cat <<EOF > /etc/init.d/scollector
 # Short-Description: start scollector
 # Description:
 ### END INIT INFO
- 
+ 
 SCOLLECTOR_BIN=$(pwd)/scollector-linux-amd64
 SCOLLECTOR_CONF=$(pwd)/scollector.toml
- 
+ 
 "\$SCOLLECTOR_BIN" -conf="\$SCOLLECTOR_CONF"
 EOF
-chmod a+x /etc/init.d/scollector
 ```
+ 
+Make the `/etc/init.d/scollector` file executable.
+ 
+  ```sh
+  chmod a+x /etc/init.d/scollector
+  ```
 
-Add scollector to startup:
+Enable scollector launch when the system is started.
 
-```
-sudo update-rc.d scollector defaults 90 10
-```
+  ```sh
+  sudo update-rc.d scollector defaults 90 10
+  ```
 
 #### Centos 6.x and RHEL 6.x
 
-Create `/etc/init.d/scollector` file from scollector installation directory and make it executable
+Create `/etc/init.d/scollector` file by running the following command in the scollector installation directory.
 
 ```sh
 sudo cat <<EOF > /etc/init.d/scollector
@@ -91,26 +90,31 @@ sudo cat <<EOF > /etc/init.d/scollector
 # Short-Description: start scollector
 # Description:
 ### END INIT INFO
- 
+ 
 SCOLLECTOR_BIN=$(pwd)/scollector-linux-amd64
 SCOLLECTOR_CONF=$(pwd)/scollector.toml
- 
+ 
 "\$SCOLLECTOR_BIN" -conf="\$SCOLLECTOR_CONF"
 EOF
+```
+
+Make the `/etc/init.d/scollector` file executable.
+
+```sh
 chmod a+x /etc/init.d/scollector
 ```
 
-Add scollector to startup:
+Enable scollector launch when the system is started.
 
-```
+```sh
 sudo chkconfig --add scollector
 ```
 
 #### Ubuntu 16.04, Centos 7.x and RHEL 7.x
 
-Create service file for scollector
+Create service file for scollector `/lib/systemd/system/scollector.service` by running the following command in the scollector installation directory.
 
-```
+```sh
 sudo cat <<EOF > /lib/systemd/system/scollector.service
 [Unit]
 Description=scollector daemon
@@ -125,9 +129,9 @@ WantedBy=multi-user.target
 EOF
 ```
 
-Add scollector to startup
+Enable scollector launch when the system is started.
 
-```
+```sh
 sudo systemctl enable scollector
 ```
 
@@ -139,7 +143,7 @@ Modify the `/etc/init.d/tcollector` content
 
 ```
 #chkconfig: 2345 90 10
-#description: scollector is a framework to collect data points and store them in a TSDB.
+#description: collect OS metrics and store them in ATSD
 ### BEGIN INIT INFO
 # Provides: scollector
 # Required-Start:
@@ -175,82 +179,44 @@ Add `User` option to `[Service]` section of the service file
 
 ## Windows
 
-1. Download scollector Windows executable from [http://bosun.org/scollector/](http://bosun.org/scollector/).
+Download scollector Windows [executable](http://bosun.org/scollector/).
 
-2. Navigate to the directory with the `exe` file and create a `scollector.toml` file in notepad.
+Navigate to the directory with the `exe` file and create a `scollector.toml` file in notepad.
 
-  **NOTE**: Make sure the name of the file is `scollector.toml` and not `scollector.toml.txt`
+> Make sure the name of the file is `scollector.toml` and not `scollector.toml.txt`
 
-3. Add the Host setting to `scollector.toml`:
+Add `Host` setting to `scollector.toml`:
 
-  `Host = "http://atsd_username:atsd_password@atsd_server:8088/"`
+ ```toml
+ Host = "http://username:password@atsd_hostname:8088/"
+ ```
 
-  **NOTE**: If you installed a root-signed SSL certificate into ATSD, you can change the above url to the secure https endpoint.
+scollector does not support untrusted SSL certificates. If you installed a CA-signed SSL certificate into ATSD, you can change the above setting to connect to the secure https endpoint.
 
-  > At this time scollector does not support communication with ATSD if its SSL certificate is self-signed.
+ ```toml
+ Host = "https://username:password@atsd_hostname:8443/"
+ ```
 
-4. Open the prompt as Administrator and create a scollector service with automated startup by executing the following command:
+Open the prompt as Administrator and create an scollector service with automated startup by executing the following command:
 
-`scollector-windows-amd64.exe -winsvc=install`
+ ```
+ scollector-windows-amd64.exe -winsvc=install
+ ```
 
-5. Start scollector service by executing the following command:
+Start scollector service by executing the following command:
 
-`scollector-windows-amd64.exe -winsvc=start`
+ ```
+ scollector-windows-amd64.exe -winsvc=start
+ ```
 
-> NOTE: If the service exits a few seconds after startup, it either cannot locate the `scollector.toml` file, this file is not valid/empty, or the Host parameter is specified without double quotes.
-Open Windows event log and review service startup error.
+If the service exits a few seconds after startup, check the following:
 
-> If the service is running but there are no scollector metrics in ATSD, verify the protocol, url, and user credentials specified in the `scollector.toml` file.
+* `scollector.toml` file doesn't exist in the same directory
+* `scollector.toml` file is not valid or is empty
+* `Host` parameter value is specified without double quotes.
+
+Open Windows event log and review the scollector service startup error.
+
+If the service is running but there are no `scollector` metrics in ATSD, verify the protocol, url, and user credentials specified in the `scollector.toml` file.
 
 
-## MacOS
-
-Download the binary file from: [http://bosun.org/scollector/](http://bosun.org/scollector/).
-
-You can find the official configuration guides here: [http://godoc.org/bosun.org/cmd/scollector](http://godoc.org/bosun.org/cmd/scollector).
-
-### Create `scollector.toml` configuration file:
-
-Navigate to the directory with the binary files and create the `scollector.toml` file.
-
-**NOTE**: Make sure the name of the file is `scollector.toml`
-
-Add Host setting to `scollector.toml`:
-
-`Host = "http://atsd_username:atsd_password@atsd_server:8088/"`
-
-**NOTE**: If you installed a root-signed SSL certificate into ATSD, you can change the above url to the secure https endpoint.
-
-> At this time scollector does not support communication with ATSD if its SSL certificate is self-signed.
-
-### Add scollector to Startup
-
-To start scollector on a system boot, add the `com.axibase.scollector.plist xml` file to the `/Library/LaunchDaemons` folder and replace the `$SCOLLECTOR_BIN` and `$SCOLLECTOR_CONF` placeholders with the correct directories.
-
-`$SCOLLECTOR_BIN` – path to the scollector binary file
-`$SCOLLECTOR_CONF` – path to the `scollector.toml` configuration file
-
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-  <dict>
-    <key>Label</key>
-      <string>scollector</string>
-    <key>ProgramArguments</key>
-      <array>
-        <string>$SCOLLECTOR_BIN</string>
-        <string>-conf=$SCOLLECTOR_CONF</string>
-      </array>
-    <key>OnDemand</key>
-      <false/>
-  </dict>
-</plist>
-view raw
-```
-### Controlling scollector
-
-`sudo launchctl load -w /Library/LaunchDaemons/com.axibase.scollector.plist` – load scollector launch configuration file
-`sudo launchctl unload -w /Library/LaunchDaemons/com.axibase.scollector.plist` – unload scollector launch configuration file
-
-`sudo launchctl stop scollector` – stop scollector daemon

--- a/integration/tcollector/README.md
+++ b/integration/tcollector/README.md
@@ -30,7 +30,7 @@ sudo yum install python
 
 ### Download tcollector
 
-```
+```sh
 wget -O tcollector.tar.gz https://github.com/OpenTSDB/tcollector/archive/v1.3.2.tar.gz
 mkdir tcollector
 tar -xzf tcollector.tar.gz -C tcollector --strip-components=1
@@ -41,7 +41,7 @@ cd tcollector
 
 ### Manual Start
 
-Start tcollector from the source code directory. Replace `atsd_hostname` with the ATSD hostname or IP address.
+Start tcollector from the installation directory. Replace `atsd_hostname` with the ATSD hostname or IP address.
 
 ```sh
 sudo ./tcollector start --host atsd_hostname --port 8081
@@ -52,10 +52,8 @@ sudo ./tcollector start --host atsd_hostname --port 8081
 Create `tcollector.conf` file in the tcollector home directory.
 
 ```sh
-cat <<EOF > tcollector.conf
 ATSD_HOST=atsd_hostname
 ATSD_PORT=8081
-EOF
 ```
 
 Replace `atsd_hostname` with the ATSD hostname or IP address.
@@ -63,16 +61,15 @@ Replace `atsd_hostname` with the ATSD hostname or IP address.
 #### Ubuntu 14.04
 
 Download [init script](resources/tcollector) and copy it into `/etc/init.d` directory.
-
-Change to the tcollector home directory and run the following command.
+Set `TCOLLECTOR_HOME` variable to tcollector home directory, for example
 
 ```sh
-sudo sed -i "/^TCOLLECTOR_HOME=/{s|=.*|=\"$(pwd)\"|}" /etc/init.d/tcollector
+TCOLLECTOR_HOME=/home/axibase/tcollector
 ```
 
 Make the script executable.
 
-```
+```sh
 sudo chmod u+x /etc/init.d/tcollector
 ```
 
@@ -91,16 +88,15 @@ sudo service tcollector start
 #### Centos 6.x and RHEL 6.x
 
 Download [init script](resources/tcollector) and copy it into `/etc/init.d` directory.
-
-Change to the tcollector home directory and run the following command.
+Set `TCOLLECTOR_HOME` variable to tcollector home directory, for example
 
 ```sh
-sudo sed -i "/^TCOLLECTOR_HOME=/{s|=.*|=\"$(pwd)\"|}" /etc/init.d/tcollector
+TCOLLECTOR_HOME=/home/axibase/tcollector
 ```
 
 Make the script executable.
 
-```
+```sh
 sudo chmod u+x /etc/init.d/tcollector
 ```
 
@@ -120,24 +116,20 @@ sudo service tcollector start
 
 Download [init script](resources/tcollector) and place it into tcollector **home** directory directory, name it `tcollector-wrapper`.
 
-Change to the tcollector home directory and run the following command.
-
-```sh
-sed -i "/^TCOLLECTOR_HOME=/{s|=.*|=\"$(pwd)\"|}" tcollector-wrapper
-```
-
 Make the script executable.
 
-```
+```sh
 chmod +x tcollector-wrapper
 ```
 
 Download [service file](resources/tcollector.service) for tcollector and copy it into `/lib/systemd/system` directory.
 
-Change to the tcollector home directory and run the following command.
+Specify path to `tcollector-wrapper` script. Example
 
-```
-sudo sed "/\(start\|stop\|restart\)/s|=|=$(pwd)/tcollector-wrapper|" /lib/systemd/system/tcollector.service
+```ini
+ExecStart=/home/axibase/tcollector/tcollector-wrapper start
+ExecStop=/home/axibase/tcollector/tcollector-wrapper stop
+ExecReload=/home/axibase/tcollector/tcollector-wrapper restart
 ```
 
 Enable autostart.
@@ -154,35 +146,36 @@ sudo systemctl start tcollector
 
 ### Autostart as a non-root user
 
-Add `LOGFILE` and `PIDFILE` options to tcollector config
+Add `LOGFILE` and `PIDFILE` options to `tcollector.conf`.
 
-```
-echo "LOGFILE=[log_file_path]" >> tcollector.conf
-echo "PIDFILE=[pid_file_path]" >> tcollector.conf
+```sh
+LOGFILE=log_file_path
+PIDFILE=pid_file_path
 ```
 
-`[log_file_path]` and `[pid_file_path]` must be absolute paths to files in existing directory (or directories), where user has write access to.
+`log_file_path` and `pid_file_path` must be absolute paths to files in existing directory (or directories), where user has write access to.
 
 #### Ubuntu 14.04, Centos 6.x, RHEL 6.x
 
-Add `RUN_AS_USER` option to tcollector config
+Add `RUN_AS_USER` option to tcollector config.
 
-```
-echo "RUN_AS_USER=[user_name]" >> tcollector.conf
+```sh
+RUN_AS_USER=user_name
 ```
 
-where `[user_name]` must be replaced with user name.
+Replace `user_name` with user name.
 
 #### Ubuntu 16.04, Centos 7.x, RHEL 7.x
 
-Add `User` option to `[Service]` section of the service file
+Add `User` option to `[Service]` section in `/lib/systemd/system/tcollector.service` file.
 
-```
- sudo sed -i '/\[Service\]/a User=[user_name]' /lib/systemd/system/tcollector.service
- sudo systemctl daemon-reload
+```ini
+ [Service]
+ User=user_name
+ ...
 ```
 
-where `[user_name]` must be replaced with user name.
+Replace `user_name` with user name.
 
 ## Default Entity Group and Portal for tcollector in ATSD
 
@@ -190,12 +183,11 @@ Entities collecting tcollector data are automatically grouped into the `tcollect
 
 Entity Group Expression:
 
-```
+```js
 properties('tcollector').size() > 0
 ```
 
 A default portal is assigned to the tcollector entity group called: `tcollector - Linux`.
-
 
 Launch live tcollector portal in Axibase Chart Lab.
 

--- a/integration/tcollector/README.md
+++ b/integration/tcollector/README.md
@@ -173,7 +173,7 @@ Download [service file](resources/tcollector.service) for tcollector and place i
 From tcollector root direcotry run this command to edit service file
 
 ```
-sed "/\(start\|stop\|restart\)/s|=|=$(pwd)/tcollector-wrapper|" /lib/systemd/system/tcollector.service
+sudo sed "/\(start\|stop\|restart\)/s|=|=$(pwd)/tcollector-wrapper|" /lib/systemd/system/tcollector.service
 ```
 
 Enable autostart

--- a/integration/tcollector/README.md
+++ b/integration/tcollector/README.md
@@ -2,68 +2,33 @@
 
 ## Overview
 
-[tcollector](https://github.com/OpenTSDB/tcollector) is a data collection framework for Linux operating system. tcollector can be configured to stream data into the Axibase Time Series Database for storage, analysis, forecasting, and visualization. Documentation can be found here: http://opentsdb.net/docs/build/html/user_guide/utilities/tcollector.html
+[tcollector](https://github.com/OpenTSDB/tcollector) is a data collection agent for Linux. tcollector can be configured to send operating system and application metrics into Axibase Time Series Database for long-term retention and analytics.
 
 ## Installation
 
-### Requirements
+### Install Python
 
-tcollector depends on Python 2 (2.5 or higher)
+tcollector requires Python 2.5 and higher.
 
-Install Python on Ubuntu 14.04:
+Install Python on Ubuntu 14.04.
 
 ```sh
 sudo apt-get install python
 ```
 
-Install Python on Ubuntu 16.04:
+Install Python on Ubuntu 16.04.
 
 ```sh
 sudo apt install python
 ```
 
-Install Python on Centos 6.x/7.x and RHEL 6.x/7.x
+Install Python on Centos 6.x/7.x and RHEL 6.x/7.x.
 
 ```sh
 sudo yum install python
 ```
 
-### Getting the source code
-
-The source code can be obtained by cloning the project repository or by downloading source code archive
-
-#### Cloning repostory
-
-To clone repository you need git to be installed.
-
-Install git on Ubuntu 14.04
-
-```
-sudo apt-get install git
-```
-
-Install git on Ubuntu 16.04
-
-```
-sudo apt install git
-```
-
-Install git on Centos 6.x/7.x and RHEL 6.x/7.x
-
-```
-sudo yum install git
-```
-
-Next, clone the repository
-
-```sh
-git clone https://github.com/OpenTSDB/tcollector.git
-cd tcollector
-```
-
-#### Downloading the source code archive
-
-As the second option, the lateset source code can be downloaded from the [latest release](https://github.com/OpenTSDB/tcollector/releases/latest) page of the project. Download it using wget or curl and copy to the target machine, if necessary.
+### Download tcollector
 
 ```
 wget -O tcollector.tar.gz https://github.com/OpenTSDB/tcollector/archive/v1.3.2.tar.gz
@@ -72,55 +37,52 @@ tar -xzf tcollector.tar.gz -C tcollector --strip-components=1
 cd tcollector
 ```
 
-## Starting tcollector
+## Start tcollector
 
-### Manual start
+### Manual Start
 
-Start tcollector from source code directory with command
+Start tcollector from the source code directory. Replace `atsd_hostname` with the ATSD hostname or IP address.
 
 ```sh
-sudo ./tcollector start --host [atsd_host] --port 8081
+sudo ./tcollector start --host atsd_hostname --port 8081
 ```
-
-where `[atsd_host]` must be replaced with ATSD host name.
 
 ### Autostart
 
-#### Create config
-
-In tcollector root directory create `tcollector.conf` file
+Create `tcollector.conf` file in the tcollector home directory.
 
 ```sh
 cat <<EOF > tcollector.conf
-ATSD_HOST=[atsd_host]
+ATSD_HOST=atsd_hostname
 ATSD_PORT=8081
 EOF
 ```
 
-where `[atsd_host]` must be replaced with ATSD host name.
+Replace `atsd_hostname` with the ATSD hostname or IP address.
 
 #### Ubuntu 14.04
 
-Download [init script](resources/tcollector) and place it into `/etc/init.d` directory.
-From root directory of tcollector installation run the following command
+Download [init script](resources/tcollector) and copy it into `/etc/init.d` directory.
+
+Change to the tcollector home directory and run the following command.
 
 ```sh
 sudo sed -i "/^TCOLLECTOR_HOME=/{s|=.*|=\"$(pwd)\"|}" /etc/init.d/tcollector
 ```
 
-Make the script executable
+Make the script executable.
 
 ```
 sudo chmod u+x /etc/init.d/tcollector
 ```
 
-Add tcollector to autostart
+Add tcollector to autostart.
 
 ```sh
 sudo update-rc.d tcollector defaults
 ```
 
-To start tcollector immidiately run
+Start tcollector.
 
 ```sh
 sudo service tcollector start
@@ -128,26 +90,27 @@ sudo service tcollector start
 
 #### Centos 6.x and RHEL 6.x
 
-Download [init script](resources/tcollector) and place it into `/etc/init.d` directory.
-From root directory of tcollector installation run the following command
+Download [init script](resources/tcollector) and copy it into `/etc/init.d` directory.
+
+Change to the tcollector home directory and run the following command.
 
 ```sh
 sudo sed -i "/^TCOLLECTOR_HOME=/{s|=.*|=\"$(pwd)\"|}" /etc/init.d/tcollector
 ```
 
-Make the script executable
+Make the script executable.
 
 ```
 sudo chmod u+x /etc/init.d/tcollector
 ```
 
-Add tcollector to autostart
+Add tcollector to autostart.
 
 ```sh
 sudo chkconfig --add tcollector
 ```
 
-To start tcollector immidiately run
+Start tcollector.
 
 ```sh
 sudo service tcollector start
@@ -155,34 +118,35 @@ sudo service tcollector start
 
 #### Ubuntu 16.04, Centos 7.x, RHEL 7.x
 
-Download [init script](resources/tcollector) and place it into tcollector root directory directory, name it `tcollector-wrapper`.
-From root directory of tcollector installation run the following command
+Download [init script](resources/tcollector) and place it into tcollector **home** directory directory, name it `tcollector-wrapper`.
+
+Change to the tcollector home directory and run the following command.
 
 ```sh
 sed -i "/^TCOLLECTOR_HOME=/{s|=.*|=\"$(pwd)\"|}" tcollector-wrapper
 ```
 
-Make the script executable
+Make the script executable.
 
 ```
 chmod +x tcollector-wrapper
 ```
 
-Download [service file](resources/tcollector.service) for tcollector and place it into `/lib/systemd/system` directory.
+Download [service file](resources/tcollector.service) for tcollector and copy it into `/lib/systemd/system` directory.
 
-From tcollector root direcotry run this command to edit service file
+Change to the tcollector home directory and run the following command.
 
 ```
 sudo sed "/\(start\|stop\|restart\)/s|=|=$(pwd)/tcollector-wrapper|" /lib/systemd/system/tcollector.service
 ```
 
-Enable autostart
+Enable autostart.
 
 ```sh
 sudo systemctl enable tcollector
 ```
 
-To start tcollector immidiately run
+Start tcollector.
 
 ```sh
 sudo systemctl start tcollector

--- a/integration/tcollector/README.md
+++ b/integration/tcollector/README.md
@@ -54,7 +54,7 @@ Install git on Centos 6.x/7.x and RHEL 6.x/7.x
 sudo yum install git
 ```
 
-Next, clone clone repository
+Next, clone the repository
 
 ```sh
 git clone https://github.com/OpenTSDB/tcollector.git

--- a/integration/tcollector/README.md
+++ b/integration/tcollector/README.md
@@ -199,7 +199,7 @@ echo "PIDFILE=[pid_file_path]" >> tcollector.conf
 
 `[log_file_path]` and `[pid_file_path]` must be absolute paths to files in existing directory (or directories), where user has write access to.
 
-#### Ubuntu 14.01, Centos 6.x, RHEL 6.x
+#### Ubuntu 14.04, Centos 6.x, RHEL 6.x
 
 Add `RUN_AS_USER` option to tcollector config
 

--- a/integration/tcollector/resources/tcollector
+++ b/integration/tcollector/resources/tcollector
@@ -1,0 +1,63 @@
+#! /bin/sh
+### BEGIN INIT INFO
+# Provides:          tcollector
+# Required-Start:    $network $remote_fs
+# Required-Stop:     $network $remote_fs
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Starts tcollector
+### END INIT INFO
+
+TCOLLECTOR_HOME=
+PATH=/sbin:/bin:/usr/sbin:/usr/bin
+TCOLLECTOR=${TCOLLECTOR_HOME}/tcollector
+
+if [ -r ${TCOLLECTOR_HOME}/tcollector.conf ]; then
+    . ${TCOLLECTOR_HOME}/tcollector.conf
+fi
+
+PIDFILE=${PIDFILE-"/var/run/tcollector.pid"}
+LOGFILE=${LOGFILE-"/var/log/tcollector.log"}
+HOSTNAME=${HOSTNAME-$(hostname)}
+
+fix_perms() {
+    local file=$1
+    if [ ! -f "$file" ]; then
+        touch "$file"
+    fi
+    chown $RUN_AS_USER "$file"
+}
+
+case $1 in
+    start)
+        find "$TCOLLECTOR_HOME" -name '*.pyc' -delete
+
+        START_CMD="$TCOLLECTOR start -H $ATSD_HOST -p $ATSD_PORT\
+            -t host=$HOSTNAME -P $PIDFILE --logfile $LOGFILE"
+
+        if [ -n "$RUN_AS_USER" ]; then
+            fix_perms $LOGFILE
+            fix_perms $PIDFILE
+            su -c "$START_CMD" $RUN_AS_USER
+        else
+            $START_CMD
+        fi
+        ;;
+
+    stop)
+        $TCOLLECTOR stop
+        ;;
+    restart|force-reload)
+        $0 stop && $0 start
+        ;;
+
+    status)
+        $TCOLLECTOR status
+        exit $?
+        ;;
+
+    *)
+        echo "Usage: $0 {start|stop|restart|force-reload|status}"
+        exit 2
+        ;;
+esac

--- a/integration/tcollector/resources/tcollector
+++ b/integration/tcollector/resources/tcollector
@@ -8,7 +8,7 @@
 # Short-Description: Starts tcollector
 ### END INIT INFO
 
-TCOLLECTOR_HOME=
+TCOLLECTOR_HOME=$(dirname $(readlink -f $0))
 PATH=/sbin:/bin:/usr/sbin:/usr/bin
 TCOLLECTOR=${TCOLLECTOR_HOME}/tcollector
 

--- a/integration/tcollector/resources/tcollector.service
+++ b/integration/tcollector/resources/tcollector.service
@@ -4,9 +4,9 @@ After=network.target
 
 [Service]
 Type=forking
-ExecStart= start
-ExecStop= stop
-ExecReload= restart
+ExecStart=tcollector-wrapper start
+ExecStop=tcollector-wrapper stop
+ExecReload=tcollector-wrapper restart
 
 [Install]
 WantedBy=multi-user.target

--- a/integration/tcollector/resources/tcollector.service
+++ b/integration/tcollector/resources/tcollector.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=tcollector daemon
+After=network.target
+
+[Service]
+Type=forking
+ExecStart= start
+ExecStop= stop
+ExecReload= restart
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Some default collector scripts from tcollector distribution expect certain applications and Python modules to be installed. Do we need to document them? And do we need to review last two sections of this instruction?