### PR TITLE
Refine usage of wildcards in tag expression.

### DIFF
--- a/api/data/series/query.md
+++ b/api/data/series/query.md
@@ -49,9 +49,9 @@ Each query contains **filter** fields to find time series in the database, **pro
 Tag Expression
 
 * The `tagExpression` can refer to series tags by name using `tags.{name}` syntax.
-* Supported operands: `LIKE`, `NOT LIKE`, `=`, `!=`, `>=`, `>`, `<=`, `<`.
+* Supported operators: `LIKE`, `NOT LIKE`, `=`, `!=`, `>=`, `>`, `<=`, `<`.
 * Supported functions: `LOWER`.
-* Supported wildcards: `?` and `*`.
+* Supported wildcards: `?` and `*`. The wildcards could be used with the `LIKE`, and `NOT LIKE` operators. Wildcards are not allowed with comparision operators: `=`, `!=`, `>=`, `>`, `<=`, `<`.
 * The series record must satisfy both the `tags` object and the `tagExpression` in order to be included in the results.
 
 ```javascript

--- a/api/data/series/query.md
+++ b/api/data/series/query.md
@@ -51,7 +51,7 @@ Tag Expression
 * The `tagExpression` can refer to series tags by name using `tags.{name}` syntax.
 * Supported operators: `LIKE`, `NOT LIKE`, `=`, `!=`, `>=`, `>`, `<=`, `<`.
 * Supported functions: `LOWER`.
-* Supported wildcards: `?` and `*`. The wildcards could be used with the `LIKE`, and `NOT LIKE` operators. Symbols `?`, and `* ` are not treated as wildcards if they are used with comparison operators `=`, `!=`, `>=`, `>`, `<=`, `<`.
+* Supported wildcards: `?` and `*`. The wildcards could be used with the `LIKE`, and `NOT LIKE` operators. Symbols `?`, and `*` are not treated as wildcards if they are used with comparison operators `=`, `!=`, `>=`, `>`, `<=`, `<`.
 * The series record must satisfy both the `tags` object and the `tagExpression` in order to be included in the results.
 
 ```javascript

--- a/api/data/series/query.md
+++ b/api/data/series/query.md
@@ -51,7 +51,7 @@ Tag Expression
 * The `tagExpression` can refer to series tags by name using `tags.{name}` syntax.
 * Supported operators: `LIKE`, `NOT LIKE`, `=`, `!=`, `>=`, `>`, `<=`, `<`.
 * Supported functions: `LOWER`.
-* Supported wildcards: `?` and `*`. The wildcards could be used with the `LIKE`, and `NOT LIKE` operators. Wildcards are not allowed with comparision operators: `=`, `!=`, `>=`, `>`, `<=`, `<`.
+* Supported wildcards: `?` and `*`. The wildcards could be used with the `LIKE`, and `NOT LIKE` operators. Symbols `?`, and `* ` are not treated as wildcards if they are used with comparison operators `=`, `!=`, `>=`, `>`, `<=`, `<`.
 * The series record must satisfy both the `tags` object and the `tagExpression` in order to be included in the results.
 
 ```javascript

--- a/api/data/series/query.md
+++ b/api/data/series/query.md
@@ -46,13 +46,13 @@ Each query contains **filter** fields to find time series in the database, **pro
 | `exactMatch` | boolean | `tags` match operator. _Exact_ match if `true`, _partial_ match if `false`. Default: **false** (_partial_ match).<br>_Exact_ match selects series with exactly the same `tags` as requested.<br>_Partial_ match selects series with tags that contain requested tags but may also include additional tags.|
 | `tagExpression` | string | An expression to include series with tags that satisfy the specified condition. |
 
-Tag Expression
+#### Tag Expression
 
 * The `tagExpression` can refer to series tags by name using `tags.{name}` syntax.
+* The series record must satisfy both the `tags` object and the `tagExpression` in order to be included in the results.
 * Supported operators: `LIKE`, `NOT LIKE`, `=`, `!=`, `>=`, `>`, `<=`, `<`.
 * Supported functions: `LOWER`.
-* Supported wildcards: `?` and `*`. The wildcards could be used with the `LIKE`, and `NOT LIKE` operators. Symbols `?`, and `*` are not treated as wildcards if they are used with comparison operators `=`, `!=`, `>=`, `>`, `<=`, `<`.
-* The series record must satisfy both the `tags` object and the `tagExpression` in order to be included in the results.
+* Wildcards `?` and `*` are supported by `LIKE` and `NOT LIKE` operators. Symbols `?` and `*` are treated as regular characters when used with comparison operators `=`, `!=`, `>=`, `>`, `<=`, `<`.
 
 ```javascript
 tags.location LIKE 'nur*'


### PR DESCRIPTION
Clearly state that wildcards may be used with LIKE, and NOT LIKE operators, and may not be used with comparison operators =, >, etc.