### PR TITLE
Fixes for code repositories

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,9 +1,11 @@
 {
   "default": true,
   "MD013": false,
+  "MD014": false,
   "MD022": true,
   "MD024": false,
   "MD033": false,
   "MD040": true,
+  "MD041": false,
   "MD045": false
 }


### PR DESCRIPTION
```
MD014/commands-show-output Dollar signs used before commands without showing output [Context: "$ mvn clean test"]
MD041/first-line-h1 First line in file should be a top level heading [Context: "[![Build Status](https://secur..."]
```
