### PR TITLE
Root pages refactor

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -415,3 +415,4 @@ timestamped
 Lucene
 wget
 Auth
+Cupertino

--- a/architecture.md
+++ b/architecture.md
@@ -1,5 +1,5 @@
 # Architecture
 
-ATSD provides both the core database engine as well as the necessary tooling for integration with the customer data pipeline.
+ATSD provides the core database engine as well as the necessary tooling for integration with the customer data pipeline.
 
 ![](./images/atsd_architecture.png)

--- a/editions.md
+++ b/editions.md
@@ -1,6 +1,6 @@
 # Editions
 
-Axibase Time Series Database (ATSD) is available in two editions: **Standard** and **Enterprise**.
+Axibase Time Series Database is available in two editions: **Standard** and **Enterprise**.
 
 Enterprise Edition supports a scale-out deployment model.
 

--- a/history.md
+++ b/history.md
@@ -12,4 +12,4 @@ We have over a decade of experience in infrastructure management systems, big da
 
 ## Progress and Road Map
 
-Our progress to date is published in publicly available [change logs](./changelogs/README.md#change-logs). Please contact us if you are interested to learn more about the ATSD road map.
+Our progress to date is published in publicly available [change logs](./changelogs/README.md#change-logs). Contact us if you are interested in learning more about the ATSD road map.

--- a/history.md
+++ b/history.md
@@ -2,7 +2,7 @@
 
 ATSD is developed by [Axibase Corporation](https://axibase.com/about-us/), a privately owned company established in 2004 and headquartered in Cupertino, CA, USA.
 
-We have decade-long experience with infrastructure management systems, big data, and analytics. With ATSD, we aim to build a specialized database with a focus on data quality and performance where time-series data is treated as a first-class citizen.
+We have over a decade of experience in infrastructure management systems, big data, and analytics. With ATSD, we sought to build a specialized database with a focus on data quality and performance where time series data is treated like a first-class citizen.
 
 ## Prototype
 

--- a/pricing.md
+++ b/pricing.md
@@ -8,6 +8,6 @@
 ## Enterprise Edition
 
 * Licensing fee is based on the number of processing nodes in the cluster.
-* Flexible options such as up `5-10` node bundles and unlimited nodes are available.
+* Flexible options: `5-10` node bundles or unlimited node choices.
 * [Axibase Collector](https://github.com/axibase/axibase-collector) licenses are **free**.
 * Contact our [sales](https://axibase.com/feedback/) for a custom quote.

--- a/schema.md
+++ b/schema.md
@@ -6,13 +6,13 @@ The table schema supports the following record types:
 * Messages
 * Properties
 
-The records are always associated with an `entity`, a generic class, which represents a physical or logical object being monitored such as `Br1740` (a bioreactor), or `eia.gov` (an institution).
+Records are always associated with an `entity`: a generic class, which represents a physical or logical object being monitored such as `Br1740` (a bioreactor), or `eia.gov` (an institution).
 
 ![](./images/atsd_schema.png)
 
 ## Series
 
-Time Series (or just Series) is a time-indexed array of measurements, each described with a timestamp and a numeric value or a text annotation.
+Time Series is a time-indexed array of measurements, each described by a timestamp and numeric value or text annotation.
 
 ```elm
 date         time       value   annotation
@@ -24,9 +24,9 @@ date         time       value   annotation
 
 Each series is uniquely identified by a composite key consisting of `metric`, `entity`, and optional key-value pairs called `tags`.
 
-* Metric represents the name of a measurable numeric attribute such as `temperature`.
-* Entity is the name of a physical or logical object being monitored such as `Br1740`(a bioreactor).
-* Tags are metadata and provide an additional level of detail about the observation, for example `part = Enclosure`.
+* `Metric` represents the name of a measurable numeric attribute such as `temperature`.
+* `Entity` is the name of a physical or logical object being monitored.
+* `Tags` are metadata and provide an additional level of detail about the observation, for example `part = Enclosure`.
 
 The above sample series can be identified as follows:
 
@@ -40,11 +40,11 @@ Series values change over time and their history can be analyzed with SQL and vi
 
 [![](./images/button.png)](https://apps.axibase.com/chartlab/075941a0/2/)
 
-The [Selecting Series Overview](./portals/selecting-series.md) contains additional examples on how to retrieve Series from the database for visualization purposes.
+The [Selecting Series Overview](./portals/selecting-series.md) contains additional examples on how to retrieve series from the database for visualization purposes.
 
 ## Messages
 
-Messages are timestamped text events (logs).
+Messages are timestamped text events also referred to as logs.
 
 ```elm
 date         time       type   source    message
@@ -56,7 +56,7 @@ date         time       type   source    message
 
 ## Properties
 
-Property is collection of arbitrary key-values describing a given entity, grouped by user-defined `type`. The property record is uniquely identified by type, entity, and optional keys. Unlike Series, the property record stores only the most recent values. The values are stored as text.
+`Property` is collection of arbitrary key-value pairs describing a given entity, grouped by user-defined `type`. The property record is uniquely identified by type, entity, and optional keys. Unlike series, the property record stores only the most recent values. The values are stored as text.
 
 For example, `disk_info` type for an entity can store properties such as `disk_type`, `disk_model` etc.  The property schema is similar to the following relational representation:
 

--- a/schema.md
+++ b/schema.md
@@ -56,7 +56,7 @@ date         time       type   source    message
 
 ## Properties
 
-`Property` is collection of arbitrary key-value pairs describing a given entity, grouped by user-defined `type`. The property record is uniquely identified by type, entity, and optional keys. Unlike series, the property record stores only the most recent values. The values are stored as text.
+`Property` is a collection of arbitrary key-value pairs describing a given entity, grouped by user-defined `type`. The property record is uniquely identified by type, entity, and optional keys. Unlike series, the property record stores only the most recent values. The values are stored as text.
 
 For example, `disk_info` type for an entity can store properties such as `disk_type`, `disk_model` etc.  The property schema is similar to the following relational representation:
 


### PR DESCRIPTION
Mostly lint-tier errors, nothing was glaring. I know we typically tend to avoid instances of "we" but I thought for `history.md` it was appropriate to scuttle that rule.