### PR TITLE
Spellchecker script fix

### DIFF
--- a/.travis-functions.sh
+++ b/.travis-functions.sh
@@ -13,7 +13,7 @@ function spellcheck {
             yaspeller --max-requests 10 --dictionary .yaspeller-dictionary.json -e ".md" ./
             yaspeller_exit_code=$?
             if [ "$1" != "--single" ]; then
-                spellchecker --language=en-US --plugins spell repeated-words syntax-mentions syntax-urls --ignore "[A-Zx0-9./_-]+" "[u0-9a-fA-F]+" "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z" "[0-9dhms:-]+" "(metric|entity|tag|[emtv])[:0-9]*" --dictionary=.spelling --files '**/*.md'
+                spellchecker --language=en-US --plugins spell repeated-words syntax-mentions syntax-urls --ignore "[A-Zx0-9./_-]+" "[u0-9a-fA-F]+" "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z" "[0-9dhms:-]+" "(metric|entity|tag|[emtv])[:0-9]*" --dictionaries .spelling --files '**/*.md'
             else 
                 return $yaspeller_exit_code
             fi
@@ -21,7 +21,7 @@ function spellcheck {
             list_modified_md_files | xargs -d '\n' -n1 yaspeller --dictionary .yaspeller-dictionary.json {}
             yaspeller_exit_code=$?
             if [ "$1" != "--single" ]; then
-                list_modified_md_files | xargs -d '\n' -n1 spellchecker --language=en-US --plugins spell repeated-words syntax-mentions syntax-urls --ignore "[A-Zx0-9./_-]+" "[u0-9a-fA-F]+" "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z" "[0-9dhms:-]+" "(metric|entity|tag|[emtv])[:0-9]*" --dictionary=.spelling --files {}
+                list_modified_md_files | xargs -d '\n' -n1 spellchecker --language=en-US --plugins spell repeated-words syntax-mentions syntax-urls --ignore "[A-Zx0-9./_-]+" "[u0-9a-fA-F]+" "[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z" "[0-9dhms:-]+" "(metric|entity|tag|[emtv])[:0-9]*" --dictionaries .spelling --files {}
             else 
                 return $yaspeller_exit_code
             fi
@@ -83,7 +83,7 @@ function generate_yaspeller_dictionary {
 }
 
 function install_checkers {
-    npm install --global --production yaspeller spellchecker-cli markdown-link-check remark-cli git+https://github.com/raipc/remark-validate-links.git git+https://github.com/VeselovAlex/markdownlint-cli.git#custom-rules
+    npm install --global --production yaspeller spellchecker-cli@4.0.0 markdown-link-check remark-cli markdownlint-cli@0.12.0 git+https://github.com/raipc/remark-validate-links.git
     if [ "$TRAVIS_REPO_SLUG" != "axibase/atsd" ]; then
         wget https://raw.githubusercontent.com/axibase/atsd/master/.spelling -O .spelling-atsd
         awk 'FNR==1{print}1' .spelling-atsd .dictionary | sort -u > .spelling


### PR DESCRIPTION
- [x] Changed `--dictionary` parameter after spellchecker version update
- [x] Use `markdownlint-cli` dependency from npm instead of custom
- [x] Freeze `markdownlint-cli` and `spellchecker-cli` versions