### PR TITLE
Freeze yaspeller version

### DIFF
--- a/.travis-functions.sh
+++ b/.travis-functions.sh
@@ -82,7 +82,7 @@ function generate_yaspeller_dictionary {
 }
 
 function install_checkers {
-    npm install --global --production yaspeller spellchecker-cli@4.0.0 markdown-link-check remark-cli markdownlint-cli@0.12.0 remark-validate-links
+    npm install --global --production yaspeller@4.2.1 spellchecker-cli@4.0.0 markdown-link-check remark-cli markdownlint-cli@0.12.0 remark-validate-links
     wget https://raw.githubusercontent.com/axibase/docs-util/master/python-scripts/dictionaries_generator.py -O dictionaries_generator.py
     if [ "$TRAVIS_REPO_SLUG" == "axibase/atsd" ]; then
         python dictionaries_generator.py --mode=atsd


### PR DESCRIPTION
We need to keep old yaspeller version (recent is 5.0.0).
In the latest version the workaround I created for dictionaries (a python script in docs-util) doesn't work. The patterns are preprocessed the same way as in spellchecker, but if the suggested replacement includes more than one word, the replacement candidate doesn't match the white list patterns.