### PR TITLE
Use atsd link whitelist for linkcheck for all repos

### DIFF
--- a/.travis-functions.sh
+++ b/.travis-functions.sh
@@ -33,11 +33,10 @@ function spellcheck {
 
 function linkcheck {
     if [[ "$ENABLE_CHECK" = "true" && -n "$(list_modified_md_files)" ]]; then
-        if [ -f ".linkcheck-config.json" ]; then
-            list_modified_md_files | xargs -d '\n' -n1 markdown-link-check -c .linkcheck-config.json
-        else
-            list_modified_md_files | xargs -d '\n' -n1 markdown-link-check
+        if [ ! -f ".linkcheck-config.json" ]; then
+            wget https://raw.githubusercontent.com/axibase/atsd/master/.linkcheck-config.json
         fi
+        list_modified_md_files | xargs -d '\n' -n1 markdown-link-check -c .linkcheck-config.json
     else
         echo "Link checking will be skipped"
     fi


### PR DESCRIPTION
As Ken already added the links from atsd-use-cases here, let's use this white list for all repositories if it  does not exist in the repo.

The question is, should we  put invalid links to this list (e.g. https://catalog.data.gov/dataset/food-insecurity-rates-2009-present) together with ones that cause false-positive result for linkchecker?