### PR TITLE
linkcheck-update

### DIFF
--- a/.linkcheck-config.json
+++ b/.linkcheck-config.json
@@ -39,6 +39,7 @@
         ,{ "pattern": "https://cdec.water.ca.gov/cgi-progs/.*"}
         ,{ "pattern": "https://cdec.water.ca.gov/index.html"}
         ,{ "pattern": "https://nylottery.ny.gov/wps/portal/.*"}
+        ,{ "pattern": "https://www.worldhunger.org/hunger-in-america-2016-united-states-hunger-poverty-facts/"}
         
         
     ]}


### PR DESCRIPTION
One of the links in `use-cases` was erroneously read as a dead link during the `cron` scheduled Travis build, so I've updated our `linkcheck` document to include it in the exception list.