### PR TITLE
cron-lint

### DIFF
--- a/.dictionary-names
+++ b/.dictionary-names
@@ -59,6 +59,7 @@ HMaster
 Holt-Winters
 Horton
 HQuorumPeer
+HRegion[s]?
 HRegionServer[s]?
 IndexNotFoundException
 IndexOutOfBoundsException
@@ -104,6 +105,7 @@ OpenJDK
 OpenLink
 OpenSUSE
 OpenView
+OSISoft
 osquery
 PagerDuty
 Pearson


### PR DESCRIPTION
* Schedule Travis CI build failed due to "misspelled" words. Those words have been added to the dictionary by this PR.