### PR TITLE
linkcheck-update

### DIFF
--- a/.linkcheck-config.json
+++ b/.linkcheck-config.json
@@ -47,4 +47,5 @@
         ,{ "pattern":"https://www.irs.gov/newsroom/2018-and-prior-year-filing-season-statistics"}
         ,{ "pattern":"https://www.ecy.wa.gov/"}
         ,{ "pattern":"https://nces.ed.gov/programs/coe/indicator_coi.asp"}
+        ,{ "pattern":"https://www.eclipse.org/"}
     ]}


### PR DESCRIPTION
`https://www.eclipse.org/` has started to show up as a dead link.