### PR TITLE
linkcheck-add-on

### DIFF
--- a/.linkcheck-config.json
+++ b/.linkcheck-config.json
@@ -50,4 +50,5 @@
         ,{ "pattern":"https://www.eclipse.org/"}
         ,{ "pattern":"https://fas.org/"}
         ,{ "pattern":"https://fas.org/irp/crs/RL31617.pdf"}
+        ,{ "pattern":"https://data.worldbank.org/country/saudi-arabia"}
     ]}

--- a/.linkcheck-config.json
+++ b/.linkcheck-config.json
@@ -48,4 +48,6 @@
         ,{ "pattern":"https://www.ecy.wa.gov/"}
         ,{ "pattern":"https://nces.ed.gov/programs/coe/indicator_coi.asp"}
         ,{ "pattern":"https://www.eclipse.org/"}
+        ,{ "pattern":"https://fas.org/"}
+        ,{ "pattern":"https://fas.org/irp/crs/RL31617.pdf"}
     ]}


### PR DESCRIPTION
* Add two Federation of American Scientists links to `linkcheck` document, because they are causing build related to a [Use Cases PR](https://github.com/axibase/atsd-use-cases/pull/372) to fails.