### PR TITLE
linkcheck-add-on

### DIFF
--- a/.linkcheck-config.json
+++ b/.linkcheck-config.json
@@ -51,4 +51,5 @@
         ,{ "pattern":"https://fas.org/"}
         ,{ "pattern":"https://fas.org/irp/crs/RL31617.pdf"}
         ,{ "pattern":"https://data.worldbank.org/country/saudi-arabia"}
+        ,{ "pattern":"https://www.washingtonpost.com/news/worldviews/wp/2017/02/10/a-potentially-historic-number-of-people-are-giving-up-their-u-s-citizenship/?noredirect=on&utm_term=.5a0d04f0ffb5"}
     ]}


### PR DESCRIPTION
A new Washington Post link is coming up dead according to Travis CI. This PR adds [that link](https://www.washingtonpost.com/news/worldviews/wp/2017/02/10/a-potentially-historic-number-of-people-are-giving-up-their-u-s-citizenship/?noredirect=on&utm_term=.5a0d04f0ffb5) to exceptions.