### PR TITLE
linkcheck-add-on

### DIFF
--- a/.linkcheck-config.json
+++ b/.linkcheck-config.json
@@ -52,4 +52,5 @@
         ,{ "pattern": "https://www.finance.senate.gov/*"}
         ,{ "pattern": "http://www.sao.ru/"}
         ,{ "pattern": "https://www.bea.gov/.*"}
+        ,{ "pattern": "https://www.nato.int/*"}
     ]}


### PR DESCRIPTION
Adds a NATO link which has sub-domains which are coming up as dead, but work.

Related to [#384](https://github.com/axibase/atsd-use-cases/pull/384).