### PR TITLE
linkcheck-add-on

### DIFF
--- a/.linkcheck-config.json
+++ b/.linkcheck-config.json
@@ -55,4 +55,5 @@
         ,{ "pattern": "https://www.nato.int/.*"}
         ,{ "pattern": "https://maven-badges.herokuapp.com/maven-central/com.axibase/.*"}
         ,{ "pattern": "https://www.britannica.com/.*"}
+        ,{ "pattern": "https://www.cs.virginia.edu/~robins/Turing_Paper_1936.pdf"}
     ]}


### PR DESCRIPTION
One of the `.edu` link is coming up dead all of a sudden.