### PR TITLE
Updated debug and message commands behavior

### DIFF
--- a/api/network/README.md
+++ b/api/network/README.md
@@ -301,7 +301,7 @@ Date limits:
 ### Enable Debug Mode
 
 By default, ATSD does not return acknowledgements to the client after processing data commands.
-Include the `debug` command at the start of the line to instruct the server to respond with `ok` for each processed command.
+Include the `debug` command at the start of the line to instruct the server to respond with `ok` or error message for each processed command.
 
 * `debug` with valid command
 
@@ -316,7 +316,7 @@ ok
 ```ls
 $ echo -e "debug my_command e:station_1 m:temperature=32.2" \
   | nc -w 1 atsd_hostname 8081
->no response, connection closed
+Invalid command: my_command e:station_1 m:temperature=32.2
 ```
 
 ### Review Client Commands

--- a/api/network/message.md
+++ b/api/network/message.md
@@ -11,7 +11,7 @@ message d:${time} e:${entity} t:type=${type} t:source=${source} t:severity=${sev
 ```
 
 * If time fields are omitted, the record is inserted with the current server time.
-* **Message text or at least one tag is required, otherwise the message is dropped silently.**
+* **Message text or at least one tag is required.**
 * Entity name and tag names are case-**insensitive** and are converted to lower case when stored.
 * Tag values and message text are case-**sensitive** and are stored as submitted.
 


### PR DESCRIPTION
Debug command actually prints error message, and this behavior is relied on in API tests.
Network command `message` prints error message if tags or message is not found, since rev. 22271.
HTTP API Message Insertion still swallows the errors silently.