### PR TITLE
Link exclusion patterns refactoring

### DIFF
--- a/.linkcheck-config.json
+++ b/.linkcheck-config.json
@@ -1,81 +1,78 @@
 {
     "ignorePatterns": [
          { "pattern": "https?://.*\\.apache.org" }
-        ,{ "pattern": "https://catalog.data.gov/*"}
+        ,{ "pattern": "https://catalog.data.gov"}
         ,{ "pattern": "https://himawari8.nict.go.jp" }
         ,{ "pattern": "https://www.maersk.com/en/hardware/triple-e"}
         ,{ "pattern": "https://aqicn.org/map/china"}
         ,{ "pattern": "https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html"}
-        ,{ "pattern": "http://www.bom.gov.au:80/fwo/IDV60801/IDV60801.94693.json"}
         ,{ "pattern": "http://www.bom.gov.au"}
         ,{ "pattern": "https://www.oracle.com/us/products/enterprise-manager/index.html"}
         ,{ "pattern": "https://java.sun.com/products/JavaManagement/download.html"}
-        ,{ "pattern": "https://apps.axibase.com/meters/"}
+        ,{ "pattern": "https://apps.axibase.com/meters"}
         ,{ "pattern": "https://ec.europa.eu"}
         ,{ "pattern": "https://crt.sh"}
-        ,{ "pattern": "https://apps.axibase.com/data-monitor/"}
-        ,{ "pattern": "https://apps.axibase.com/performance/"}
-        ,{ "pattern": "https://java.com/en/"}
-        ,{ "pattern": "https://www.census.gov/2010census/data/"}
+        ,{ "pattern": "https://apps.axibase.com/data-monitor"}
+        ,{ "pattern": "https://apps.axibase.com/performance"}
+        ,{ "pattern": "https://java.com/en"}
         ,{ "pattern": "https://www.uscis.gov/news/fact-sheets/naturalization-fact-sheet"}
-        ,{ "pattern": "https://www.census.gov/main/www/cen2000.html"}
-        ,{ "pattern": "http://www.aei.org/publication/team-obama-sorry-america-the-new-normal-may-be-here-to-stay/"}
+        ,{ "pattern": "http://www.aei.org/publication/team-obama-sorry-america-the-new-normal-may-be-here-to-stay"}
         ,{ "pattern": "https://www.census.gov"}
-        ,{ "pattern": "https://www.census.gov/foreign-trade/balance/index.html"}
         ,{ "pattern": "https://www.state.gov/documents/organization/249770.pdf"}
         ,{ "pattern": "https://www.state.gov/s/d/rm/rls/perfrpt/2015/html/249727.htm" }
         ,{ "pattern": "https://www.oracle.com/technetwork/java/javase/9all-relnotes-3704433.html#JDK-8189131" }
         ,{ "pattern": "https://www.panynj.gov/port/pdf/port-trade-statistics-summary-2001-2011.pdf" }
-        ,{ "pattern": "https://www.airnowapi.org/" }
+        ,{ "pattern": "https://www.airnowapi.org" }
         ,{ "pattern": "https://web.stanford.edu/group/recessiontrends/cgi-bin/web/sites/all/themes/barron/pdf/IncomeWealthDebt_fact_sheet.pdf" }
-        ,{ "pattern": "https://www.iowa.gov/" }
+        ,{ "pattern": "https://www.iowa.gov" }
         ,{ "pattern": "https://cms.montgomerycollege.edu/EDU/Department.aspx?id=45574" }
         ,{ "pattern": "http://net-snmp.sourceforge.net/tutorial/tutorial-5/commands/snmptranslate.html" }
-        ,{ "pattern": "https://www.boi.org.il/.*"}
-        ,{ "pattern": "https://www.water-research.net/" }
-        ,{ "pattern": "https://data.maryland.gov/api/views/.*"}
-        ,{ "pattern": "https://www.ssb.no/statistikkbanken/selectvarval/Define.asp.*"}
-        ,{ "pattern": "https://www.portoflosangeles.org/.*"}
-        ,{ "pattern": "https://cdec.water.ca.gov/cgi-progs/.*"}
-        ,{ "pattern": "https://cdec.water.ca.gov/index.html"}
-        ,{ "pattern": "https://nylottery.ny.gov/wps/portal/.*"}
-        ,{ "pattern": "https://www.worldhunger.org/hunger-in-america-2016-united-states-hunger-poverty-facts/"}
-        ,{ "pattern": "https://www.irs.gov/.*"}
-        ,{ "pattern": "https://www.ecy.wa.gov/"}
+        ,{ "pattern": "https://www.boi.org.il"}
+        ,{ "pattern": "https://www.water-research.net" }
+        ,{ "pattern": "https://data.maryland.gov/api/views"}
+        ,{ "pattern": "https://www.ssb.no/statistikkbanken/selectvarval/Define.asp"}
+        ,{ "pattern": "https://www.portoflosangeles.org"}
+        ,{ "pattern": "https://cdec.water.ca.gov"}
+        ,{ "pattern": "https://nylottery.ny.gov/wps/portal"}
+        ,{ "pattern": "https://www.worldhunger.org/hunger-in-america-2016-united-states-hunger-poverty-facts"}
+        ,{ "pattern": "https://www.irs.gov"}
+        ,{ "pattern": "https://www.ecy.wa.gov"}
         ,{ "pattern": "https://nces.ed.gov/programs/coe/indicator_coi.asp"}
-        ,{ "pattern": "https://www.eclipse.org/"}
-        ,{ "pattern": "https://fas.org/.*"}
+        ,{ "pattern": "https://www.eclipse.org"}
+        ,{ "pattern": "https://fas.org"}
         ,{ "pattern": "https://data.worldbank.org/country/saudi-arabia"}
-        ,{ "pattern": "https://www.washingtonpost.com/.*"}
+        ,{ "pattern": "https://www.washingtonpost.com"}
         ,{ "pattern": "https://www.niddk.nih.gov/health-information/health-statistics/overweight-obesity"}
-        ,{ "pattern": "https://www.senate.gov/.*"}
-        ,{ "pattern": "https://www.finance.senate.gov/.*"}
-        ,{ "pattern": "http://www.sao.ru/"}
-        ,{ "pattern": "https://www.bea.gov/.*"}
-        ,{ "pattern": "https://www.nato.int/.*"}
-        ,{ "pattern": "https://maven-badges.herokuapp.com/maven-central/com.axibase/.*"}
-        ,{ "pattern": "https://www.britannica.com/.*"}
+        ,{ "pattern": "https://www.senate.gov"}
+        ,{ "pattern": "https://www.finance.senate.gov"}
+        ,{ "pattern": "http://www.sao.ru"}
+        ,{ "pattern": "https://www.bea.gov"}
+        ,{ "pattern": "https://www.nato.int"}
+        ,{ "pattern": "https://maven-badges.herokuapp.com/maven-central/com.axibase"}
+        ,{ "pattern": "https://www.britannica.com"}
         ,{ "pattern": "https://www.cs.virginia.edu/~robins/Turing_Paper_1936.pdf"}
-        ,{ "pattern": "http://www.mva.maryland.gov/"}
+        ,{ "pattern": "http://www.mva.maryland.gov"}
         ,{ "pattern": "https://www.odh.ohio.gov/healthstats/vitalstats/deathstat.aspx"}
-        ,{ "pattern": "https://sd24.senate.ca.gov/news.*"}
-        ,{ "pattern": "https://www.highcharts.com/"}
-        ,{ "pattern": "https://data.cityofnewyork.us/.*"}
+        ,{ "pattern": "https://sd24.senate.ca.gov/news"}
+        ,{ "pattern": "https://www.highcharts.com"}
+        ,{ "pattern": "https://data.cityofnewyork.us"}
         ,{ "pattern": "https://www.itl.nist.gov/div898/software/dataplot/refman2/auxillar/percenti.htm"}
         ,{ "pattern": "https://www.itl.nist.gov/div898/handbook/prc/section2/prc262.htm"}
         ,{ "pattern": "https://faculty.history.wisc.edu/sommerville/351/dutch%20republic.htm"}
         ,{ "pattern": "https://www.opec.org/opec_web/en/press_room/4749.htm"}
         ,{ "pattern": "http://www.rubincenter.org/meria/2005/06/Duffield%20pdf.pdf"}
         ,{ "pattern": "http://ops-alaska.com/time/gangale_converter/calendar_clock.htm"}
-        ,{ "pattern": "http://www.killedbypolice.net/"}
+        ,{ "pattern": "http://www.killedbypolice.net"}
         ,{ "pattern": "https://vision2030.gov.sa/en/node/125"}
-        ,{ "pattern": "https://www.sacbee.com/news/.*"}
-        ,{ "pattern": "https://www.fresnobee.com/news/.*"}
-        ,{ "pattern": "https://www.timeanddate.com/weather/.*"}
+        ,{ "pattern": "https://www.sacbee.com/news"}
+        ,{ "pattern": "https://www.fresnobee.com/news"}
+        ,{ "pattern": "https://www.timeanddate.com/weather"}
         ,{ "pattern": "https://www.comodo.com"}
-        ,{ "pattern": "https://www.youtube.com/.*"}
-        ,{ "pattern": "https://www.youtu.be/.*"}
-        ,{ "pattern": "https://www.statisticshowto.datasciencecentral.com/.*"}
-        ,{ "pattern": "https://stats.oecd.org/Index.aspx.*"}
+        ,{ "pattern": "https://www.youtube.com"}
+        ,{ "pattern": "https://www.youtu.be"}
+        ,{ "pattern": "https://www.statisticshowto.datasciencecentral.com"}
+        ,{ "pattern": "https://stats.oecd.org/Index.aspx"}
+        ,{ "pattern": "https://mysql.com"}
+        ,{ "pattern": "https://web.archive.org"}
     ]
 }


### PR DESCRIPTION
`linkcheck` tests patterns for exclusion using `find` method instead of `match`, so the patterns can be simplified.
Also mysql.com (socket error, but the domain will hardly disappear) and web.archive.org (slow) added to exclusion list