### PR TITLE
Fix error in query with lead

### DIFF
--- a/sql/examples/partition-lag.md
+++ b/sql/examples/partition-lag.md
@@ -51,9 +51,9 @@ ORDER BY entity, tags, datetime
 
 ```sql
 SELECT entity, datetime, value,
-  LAG(value),
-  LAG(value, 3),
-  LAG(value, 3, -1)
+  LEAD(value),
+  LEAD(value, 3),
+  LEAD(value, 3, -1)
   FROM "distance"
 WHERE datetime BETWEEN '2018-12-01T00:00:00Z' AND '2018-12-01T05:00:00Z' EXCL
   AND entity = 'car-1'


### PR DESCRIPTION
We have two identical queries in docs with different output. It seems that one of them was accidentally copied from another one https://axibase.com/docs/atsd/sql/examples/partition-lag.html#lag