### PR TITLE
Support per-route navbar links and home href

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -433,6 +433,15 @@ module.exports = {
     staticFilesExtensionsTest: /(?:tcollector|\.(?:pdf|xlsx?|xml|txt|csv|str|java|json|sql|sps|yxmd|htm|py|prpt|do|tdc|jsonld|ktr|service|sh|ya?ml|lua|properties|conf(?:ig)?))$/,
     themeConfig: {
         nav: topNavMenu,
+        navByPath: {
+            "/finance/": [],
+            "/": topNavMenu,
+            "": [],
+        },
+        homePageByPath: {
+            "/finance/": "/finance/" ,
+            "": "/",
+        },
         logo: '/images/axibase_logo_site.png',
         algolia: {
             appId: 'BH4D9OD16A',

--- a/.vuepress/theme/Layout.vue
+++ b/.vuepress/theme/Layout.vue
@@ -3,7 +3,7 @@
     :class="pageClasses"
     @touchstart="onTouchStart"
     @touchend="onTouchEnd">
-    <Navbar v-if="shouldShowNavbar" @toggle-sidebar="toggleSidebar"/>
+    <Navbar v-if="shouldShowNavbar" @toggle-sidebar="toggleSidebar" :navbar-items="navbarItems" :homeURL="homeURL"/>
     <div class="sidebar-mask" @click="toggleSidebar(false)"></div>
     <Sidebar :items="sidebarItems" @toggle-sidebar="toggleSidebar">
       <slot name="sidebar-top" slot="top"/>
@@ -28,7 +28,7 @@ import Navbar from './Navbar.vue'
 import Page from './Page.vue'
 import Sidebar from './Sidebar.vue'
 import { pathToComponentName } from '@app/util'
-import { resolveSidebarItems } from './util'
+import { resolveSidebarItems, resolveNavbarItems, resolveHomeURL } from './util'
 
 export default {
   components: { Home, Page, Sidebar, Navbar },
@@ -60,6 +60,22 @@ export default {
         frontmatter.sidebar !== false &&
         this.sidebarItems.length
       )
+    },
+    navbarItems () {
+      return resolveNavbarItems(
+        this.$page,
+        this.$route,
+        this.$site,
+        this.$localePath
+      );
+    },
+    homeURL () {
+      return resolveHomeURL(
+        this.$page,
+        this.$route,
+        this.$site,
+        this.$localePath
+      );
     },
     sidebarItems () {
       return resolveSidebarItems(

--- a/.vuepress/theme/NavLinks.vue
+++ b/.vuepress/theme/NavLinks.vue
@@ -28,9 +28,10 @@ import NavLink from './NavLink.vue'
 
 export default {
   components: { OutboundLink, NavLink, DropdownLink },
+  props: ["pageNav"],
   computed: {
     userNav () {
-      return this.$themeLocaleConfig.nav || this.$site.themeConfig.nav || []
+      return this.pageNav || this.$themeLocaleConfig.nav || this.$site.themeConfig.nav || []
     },
     nav () {
       const { locales } = this.$site

--- a/.vuepress/theme/Navbar.vue
+++ b/.vuepress/theme/Navbar.vue
@@ -1,7 +1,7 @@
 <template>
   <header class="navbar">
     <SidebarButton @toggle-sidebar="$emit('toggle-sidebar')"/>
-    <router-link :to="$localePath" class="home-link">
+    <router-link :to="homePath" class="home-link">
       <img class="logo"
         v-if="$site.themeConfig.logo"
         :src="$withBase($site.themeConfig.logo)">
@@ -12,7 +12,7 @@
       </span>
     </router-link>
     <div class="links">
-      <NavLinks class="can-hide"/>
+      <NavLinks class="can-hide" :pageNav="navbarItems" />
       <AlgoliaSearchBox v-if="isAlgoliaSearch" :options="algolia"/>
       <SearchBox v-else-if="$site.themeConfig.search !== false"/>
     </div>
@@ -27,12 +27,17 @@ import NavLinks from './NavLinks.vue'
 
 export default {
   components: { SidebarButton, NavLinks, SearchBox, AlgoliaSearchBox },
+  props: ["navbarItems", "homeURL"],
   computed: {
     algolia () {
       return this.$themeLocaleConfig.algolia || this.$site.themeConfig.algolia || {}
     },
     isAlgoliaSearch () {
       return this.algolia && this.algolia.apiKey && this.algolia.indexName
+    },
+
+    homePath() {
+      return this.homeURL || this.$localePath;
     }
   }
 }

--- a/.vuepress/theme/util.js
+++ b/.vuepress/theme/util.js
@@ -132,6 +132,44 @@ export function resolveSidebarItems (page, route, site, localePath) {
   }
 }
 
+
+export function resolveHomeURL (page, route, site, localePath) {
+  const { themeConfig } = site
+
+  const localeConfig = localePath && themeConfig.locales
+    ? themeConfig.locales[localePath] || themeConfig
+    : themeConfig
+
+    const homepageConfig = localeConfig.homePageByPath || themeConfig.homePageByPath
+    if (!homepageConfig) {
+      return "";
+    } else {
+    const { config } = resolveMatchingConfig(route, homepageConfig)
+    return config || "";
+  }
+}
+
+export function resolveNavbarItems (page, route, site, localePath) {
+  const pageNavbarConfig = page.frontmatter.navbar
+  if (pageNavbarConfig === false) {
+    return [];
+  }
+
+  const { themeConfig } = site
+
+  const localeConfig = localePath && themeConfig.locales
+    ? themeConfig.locales[localePath] || themeConfig
+    : themeConfig
+
+  const navbarConfig = localeConfig.navByPath || themeConfig.navByPath
+  if (!navbarConfig) {
+    return null
+  } else {
+    const { config } = resolveMatchingConfig(route, navbarConfig)
+    return config || []
+  }
+}
+
 function resolveHeaders (page) {
   const headers = groupHeaders(page.headers || [])
   return [{


### PR DESCRIPTION
Allow to customize navbar and homepage link for specific routes, e.g. /finance/.
Remove navbar links for `/finance/` pages, set home link to `/docs/atsd/finance/`.