### PR TITLE
Add 'Contact Us' form to landing page

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -452,6 +452,10 @@ module.exports = {
             "/finance/": "/finance/",
             "": "/",
         },
+        feedback: {
+            title: "Contact Axibase",
+            url: "/feedback/"
+        },
         trackNavURL: "/tracknav/",
         logo: '/images/axibase_logo_site.png',
         algolia: {

--- a/.vuepress/theme/ContactUs.vue
+++ b/.vuepress/theme/ContactUs.vue
@@ -1,0 +1,185 @@
+<template>
+  <section v-if="url" class="contact-us-block">
+    <h2>{{ labels.title || "" }}</h2>
+    <p class="send-status" v-if="sendStatus=='success'">
+      {{ labels.successText || "" }}
+    </p>
+    <template v-else>
+      <p class="send-status" v-if="sendStatus=='error'">
+        {{ labels.errorText || "" }}
+      </p>
+      <form :action="url" method="POST" ref="form" v-on:submit.prevent="sendForm">
+        <p>
+          <input name="avia_1_1" required type="text" v-model="form.firstName" :placeholder="labels.firstNameText + '*'">
+          <input name="avia_2_1" required type="text" v-model="form.lastName" :placeholder="labels.lastNameText + '*'">
+        </p>
+        <p>
+          <input name="avia_3_1" required type="text" v-model="form.company" :placeholder="labels.companyText + '*'">
+        </p>
+        <p>
+          <input name="avia_4_1" required type="email" v-model="form.email" :placeholder="labels.emailText + '*'">
+        </p>
+        <p v-if="hasText">
+          <textarea required name="avia_5_1" v-model="form.message" :placeholder="labels.messageText + '*'"></textarea>
+        </p>
+        <p>
+          <input name="avia_6_1" type="hidden" value="">
+          <input name="avia_6_1" type="hidden" value="674443354">
+          <input name="avia_7_1" type="hidden" value="4">
+        </p>
+        <p>
+          <button type="submit">{{ labels.submitText }}</button>
+        </p>
+      </form>
+    </template>
+  </section>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      sendStatus: "",
+      form: {
+        firstName: "",
+        lastName: "",
+        company: "",
+        email: "",
+        message: "",
+      }
+    };
+  },
+  props: [ "options" ],
+  computed: {
+    url() {
+      return (this.options && this.options.url)
+        || (this.$site.themeConfig.feedback && this.$site.themeConfig.feedback.url);
+    },
+    labels() {
+      var defaults = {
+        firstNameText: "First Name",
+        lastNameText: "Last Name",
+        emailText: "E-Mail",
+        companyText: "Organization",
+        messageText: "Message",
+        submitText: "Submit",
+        errorText: "Something went wrong, please, try again later",
+        successText: "Submitted successfully",
+        title: "Contact Us"
+      };
+      var options = (!this.options || typeof this.options !== "object") ? {} : this.options;
+      var siteOptions = this.$site.themeConfig.feedback || {};
+      return {...defaults, ...siteOptions, ...options};
+    },
+    hasText() {
+      return !(this.options && this.options.content);
+    }
+  },
+  methods: {
+    sendForm() {
+      /** @type {HTMLFormElement} */
+      let form = this.$refs.form;
+      if (!form && !form.checkValidity()) return;
+
+      let text = this.hasText ? this.form.message : this.options.content;
+      let params = [
+        this.form.firstName,
+        this.form.lastName,
+        this.form.company,
+        this.form.email,
+        text,
+        "",
+        "674443354",
+        "4"
+      ];
+      let qs = params.map((v, i) => `avia_${i+1}_ 1=${encodeURIComponent(v)}`).join('&');
+      let url = this.url + '?' + qs;
+
+      let xhr = new XMLHttpRequest();
+      xhr.open("POST", url, true);
+      xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded;charset=UTF-8")
+      xhr.onload = () => {
+        this.sendStatus = (xhr.status >= 400) ? "error" : "success";
+      };
+      xhr.onerror = xhr.onabort = xhr.ontimeout = () => {
+        this.sendStatus = "error";
+      };
+      xhr.send(null);
+    }
+  }
+}
+</script>
+
+<style lang="stylus">
+@import './styles/config.styl'
+
+.contact-us-block
+  width 60%
+  min-height 240px
+  margin 0 auto
+
+  h2
+    margin 0.4rem 0.5rem
+
+  p
+    width 100%
+    display flex
+
+  .send-status
+    margin 1.2rem 0.5rem
+    font-size 1.2rem
+
+  input, textarea, button
+    border-radius 4px
+    border 1px solid #ddd
+    display block
+    margin 0 0.5rem
+
+    &:focus
+      outline none 
+      border-color $accentColor
+      box-shadow 0 0 2px 1px $accentColor
+
+  button
+    padding 0.8rem 1.6rem 
+    border-color $accentColor
+    background-color $accentColor
+    color #fff
+    font-size 1.2rem
+    background-color 0.1s ease
+    font-weight 500
+    cursor pointer
+    border-bottom-color darken($accentColor, 10%)
+
+    &:hover
+      background-color lighten($accentColor, 10%)
+
+  input, textarea
+    padding 0.8rem
+    width 100%
+    font-size 1rem
+
+  textarea
+    font inherit 
+    line-height 1.2
+    min-height 8rem
+    resize vertical
+      
+@media (max-width: $MQMobile)
+  .contact-us-block
+    width 80%
+
+@media (max-width: $MQMobileNarrow)
+  .contact-us-block
+    width 100%
+
+    p
+      flex-wrap wrap
+
+      input:not(:first-child)
+        margin-top 0.5rem
+
+    button
+      width 100%
+
+</style>

--- a/.vuepress/theme/Home.vue
+++ b/.vuepress/theme/Home.vue
@@ -20,6 +20,10 @@
         </div>
       </div>
       <Content custom/>
+      <div v-if="data.resetStripes"></div>
+      <div class="contact-form" id="contact-us" v-if="data.contactUs">
+        <ContactUs :options="data.contactUs" />
+      </div>
       <div v-if="data.footerActionText && data.footerActionLink" class="footer-action">
         <NavLink class="action-button" :item="footerActionLink"/>
       </div>
@@ -32,9 +36,10 @@
 
 <script>
 import NavLink from './NavLink.vue'
+import ContactUs from './ContactUs.vue'
 
 export default {
-  components: { NavLink },
+  components: { NavLink, ContactUs },
   computed: {
     data () {
       return this.$page.frontmatter
@@ -131,9 +136,34 @@ export default {
     display block
     margin 0 auto;
 
+  .feature-highlight, .contact-form, .footer-action
+    position: relative;
+
+    &:before
+      content: ''
+      position: absolute;
+      left: -100vw;
+      width: 200vw;
+      display: block;
+      height: 100%;
+      top: 0;
+      z-index: -1;
+
+      background: #f5f5f5
+      box-shadow: 0 14px 6px -12px rgba(0,0,0,0.2) inset
+      // Inversion 
+      // background: #233453
+      // background: linear-gradient(-30deg, lighten(#233453, 20%),darken(#233453, 20%))
+      // background: #19325b
+      // background: linear-gradient(-30deg, lighten(#19325b, 20%),darken(#19325b, 20%))
+
+    &:nth-child(even):before
+      background: #fefefe;
+      box-shadow: 0 14px 6px -12px rgba(0,0,0,0.3) inset
+    
+
   .feature-highlight
     min-height: 240px;
-    position: relative;
     padding: 40px;
 
     &:nth-child(odd)
@@ -148,16 +178,7 @@ export default {
 
       .feature-images
         left: -490px
-      
-      &:before
-        background: #f5f5f5
-        box-shadow: 0 14px 6px -12px rgba(0,0,0,0.2) inset
-      // Inversion 
-      // background: #233453
-      // background: linear-gradient(-30deg, lighten(#233453, 20%),darken(#233453, 20%))
-      // background: #19325b
-      // background: linear-gradient(-30deg, lighten(#19325b, 20%),darken(#19325b, 20%))
-
+    
         
     &:nth-child(even)
       margin-right: 30%
@@ -165,20 +186,6 @@ export default {
 
       .feature-images
         right: -490px;
-      
-      &:before
-        background: #fefefe;
-        box-shadow: 0 14px 6px -12px rgba(0,0,0,0.3) inset
-
-    &:before
-      content: ''
-      position: absolute;
-      left: -100vw;
-      width: 200vw;
-      display: block;
-      height: 100%;
-      top: 0;
-      z-index: -1;
 
     .feature-images
       position: absolute;
@@ -219,6 +226,9 @@ export default {
     border-top 1px solid $borderColor
     text-align center
     color lighten($textColor, 25%)
+
+  .contact-form
+    padding 2rem 0
 
 @media (max-width: 1024px)
   .home

--- a/finance/ru/README.md
+++ b/finance/ru/README.md
@@ -15,8 +15,21 @@ features:
 - title: Продвинутый SQL и распределенные вычисления
   details: Расширенный <a href="sql.html" style="color:orange">SQL</a> синтаксис с оптимизированными вычислениями.
 footer: Copyright © 2021 Axibase
-footerActionText: Установка
-footerActionLink: ./install.md
+resetStripes: true # If last feature stripe in content is white (even number of highlighted features), set it to true
+# contactUs: true # Add default feedback form
+contactUs:
+  # title: Запросить демо-доступ
+  title: Request Trial
+  content: Trial request for financial version
+  # submitText: Отправить
+  # firstNameText: First Name
+  # lastNameText: Last Name
+  # emailText: E-Mail
+  # companyText: Organization
+  # messageText: Message
+  # errorText: Something went wrong, please, try again later
+  # successText: Submitted successfully
+    
 # /* yaspeller ignore:end */
 ---
 <!-- markdownlint-disable MD002 MD041 MD012 -->


### PR DESCRIPTION
<img width="620" alt="изображение" src="https://user-images.githubusercontent.com/3617329/112676732-da532080-8e79-11eb-99fc-341d6465362f.png">

Configuration properties:
* `url` - form submission POST endpoint, `/feedback/`
* `title` - form title, default `Contact Us`
* `content` - if string value is set, send given value instead for user's message
* `submitText`, `firstNameText`, `lastNameText`, `emailText`, `companyText`, `messageText` - override form field labels for l10n
* `errorText` - message if submission failed, default `Something went wrong, please, try again later`
 * `successText` - message on success, default `Submitted successfully`

Configuration may be set in `config.js::themeConfig.feedback` or `contactUs` option in frontmatter. Also you can use `contactUs: true` for default form. Form is shown only if page is landing and `contactUs` is present in frontmatter 