### PR TITLE
Track clicks to `Request Trial` link

### DIFF
--- a/.vuepress/theme/Home.vue
+++ b/.vuepress/theme/Home.vue
@@ -11,7 +11,7 @@
         </p>
         <p class="action" v-if="data.actionText && data.actionLink">
           <NavLink class="action-button" :item="actionLink"/>
-          <a class="action-button contact-button nav-link" v-if="contactUsLink" :href="contactUsLink.link">
+          <a class="action-button contact-button nav-link" v-if="contactUsLink" :href="contactUsLink.link" @click="trackNavigationToContactUs">
             {{ contactUsLink.text }}
           </a>
         </p>
@@ -40,6 +40,7 @@
 <script>
 import NavLink from './NavLink.vue'
 import ContactUs from './ContactUs.vue'
+import { trackNavigation } from "./tracknav"
 
 export default {
   components: { NavLink, ContactUs },
@@ -64,6 +65,13 @@ export default {
         link: this.data.footerActionLink,
         text: this.data.footerActionText
       }
+    }
+  },
+  methods: {
+    trackNavigationToContactUs() {
+      let url = this.$site.themeConfig.trackNavURL;
+      const pageUrl = location.href;
+      trackNavigation(url, pageUrl, pageUrl, {"section": "contact-us"})
     }
   },
   mounted() {

--- a/.vuepress/theme/enhanceApp.js
+++ b/.vuepress/theme/enhanceApp.js
@@ -1,5 +1,8 @@
+import { trackNavigation } from "./tracknav";
+
 export default function ({siteData, router}) {
     var remarkConfig = siteData.themeConfig.remark42Config;
+    var trackNavUrl = siteData.themeConfig.trackNavURL;
 
     if (remarkConfig && typeof window !== "undefined") {
         window.remark_config = { ...remarkConfig };
@@ -16,21 +19,12 @@ export default function ({siteData, router}) {
     }
 
     if (siteData.themeConfig.trackNavURL) {
-        var trackNav = siteData.themeConfig.trackNavURL;
         router.afterEach((to, from) => {
-            try {
-                var isInitial = from.name === null && from.fullPath === "/";
-                if (isInitial) return;
-
-                var fromParam = encodeURIComponent(siteData.base + from.fullPath.slice(1));
-                var toParam = encodeURIComponent(siteData.base + to.fullPath.slice(1));
-                var xhr = new XMLHttpRequest();
-                xhr.onerror = function () {};
-                xhr.open("POST", `${trackNav}?from=${fromParam}&to=${toParam}`, true);
-                xhr.send(null);
-            } catch (e) {
-                // NOP
-            }
+            var isInitial = from == null || (from.name === null && from.fullPath === "/");
+            if (isInitial) return;
+            const fromUrl = siteData.base + from.fullPath.slice(1);
+            const toUrl = siteData.base + to.fullPath.slice(1);
+            trackNavigation(trackNavUrl, fromUrl, toUrl);
         });
     }
 }

--- a/.vuepress/theme/tracknav.js
+++ b/.vuepress/theme/tracknav.js
@@ -1,0 +1,16 @@
+export function trackNavigation(url, from, to, meta) {
+    if (!url) return;
+    try {
+        var fromParam = encodeURIComponent(from);
+        var toParam = encodeURIComponent(to);
+        var metaParams = meta
+            ? "&" + Object.keys(meta).map((key) => `${encodeURIComponent(key)}=${encodeURIComponent(meta[key])}`).join("&")
+            : "";
+        var xhr = new XMLHttpRequest();
+        xhr.onerror = function () {};
+        xhr.open("POST", `${url}?from=${fromParam}&to=${toParam}${metaParams}`, true);
+        xhr.send(null);
+    } catch (e) {
+        // NOP
+    }
+}


### PR DESCRIPTION
Tracks are sent with from/to parameters, as well as `section=contact-us` parameter to filter this clicks in messages list.

This solution introduces some duplication, but it cannot be removed until an issue will be fixed in vue-router (issue 1668)