### PR TITLE
ConsumerLatencyParser: Concurrent implementation

### DIFF
--- a/finance/ru/ConsumerLatencyParser.java
+++ b/finance/ru/ConsumerLatencyParser.java
@@ -1,57 +1,99 @@
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.ZoneId;
+import java.io.*;
+import java.time.*;
 import java.time.format.DateTimeFormatter;
-import java.time.temporal.ChronoUnit;
 import java.util.*;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.function.IntPredicate;
+import java.util.function.Supplier;
+import java.util.function.ToDoubleFunction;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.zip.GZIPInputStream;
 
-import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
+import org.apache.commons.math3.stat.descriptive.rank.Max;
+import org.apache.commons.math3.stat.descriptive.rank.Min;
+import org.apache.commons.math3.stat.descriptive.rank.Percentile;
+import org.apache.commons.math3.util.FastMath;
+import org.apache.commons.math3.util.Pair;
+import org.apache.commons.math3.util.ResizableDoubleArray;
 
 public class ConsumerLatencyParser {
+	private static final int TYPE_DERIVATIVES = 1;
+	private static final int TYPE_INDEX = 2;
+	private static final int TYPE_FOND = 3;
+	private static final int TYPE_FX = 4;
+	private static final DateTimeFormatter DTF_FULL = DateTimeFormatter.ofPattern("yyMMddHHmmssSSSSSS");
+	private static final long NANOS_IN_DAY = TimeUnit.DAYS.toNanos(1);
+	private static final long NANOS_IN_MINUTE = TimeUnit.MINUTES.toNanos(1);
+	private static final long NANOS_IN_SECOND = TimeUnit.SECONDS.toNanos(1);
+	private static final long NANOS_IN_MICROS = TimeUnit.MICROSECONDS.toNanos(1);
+	private static final ZoneId UTC = ZoneId.of("UTC");
+	private static final Map<String, ToDoubleFunction<ResizableDoubleArray>> STATISTICS_CALCULATORS = prepareStatisticsCalculators();
 
-	public static int fileIndex(File f) {
-		String name = f.getName();
-		//statistics.19-02-2021.1.log.gz
-		String[] parts = name.split("\\.");
-		return Integer.parseInt(parts[parts.length-3]);
+	private static Map<String, ToDoubleFunction<ResizableDoubleArray>> prepareStatisticsCalculators() {
+		final Map<String, ToDoubleFunction<ResizableDoubleArray>> calculators = new LinkedHashMap<>();
+		calculators.put("count", ResizableDoubleArray::getNumElements);
+		calculators.put("min", array -> array.compute(new Min()));
+		for (String rank : "0.1,1,5,10,25,50,75,90,95,99,99.9".split(",")) {
+			double quantile = Double.parseDouble(rank);
+			calculators.put("p" + rank, array -> array.compute(new Percentile(quantile)));
+		}
+		calculators.put("max", array -> array.compute(new Max()));
+		return calculators;
 	}
 
-	private static final DateTimeFormatter DTF_MIN = DateTimeFormatter.ofPattern("yyMMddHHmm");
-	private static final DateTimeFormatter TF_MIN = DateTimeFormatter.ofPattern("HHmm");
+	private final ResizableDoubleArray sendingToProcess = new ResizableDoubleArray(100_000);
+	private final ResizableDoubleArray lastUpdateToProcess = new ResizableDoubleArray(100_000);
+	private final ResizableDoubleArray receiveToProcess = new ResizableDoubleArray(100_000);
+	private final ResizableDoubleArray entryToProcess = new ResizableDoubleArray(100_000);
+	private final ResizableDoubleArray lastUpdateToSending = new ResizableDoubleArray(100_000);
+	private final ResizableDoubleArray sendingToReceive = new ResizableDoubleArray(100_000);
+	private final ResizableDoubleArray entryToSending = new ResizableDoubleArray(100_000);
+	private final ResizableByteArray actions = new ResizableByteArray(100_000);
+	private final ResizableByteArray types = new ResizableByteArray(100_000);
+	private final SetsContainer sets = new SetsContainer();
 
-	// not Thread-safe, but 40% faster
-	//210224180237044631 > 2102241802 37044631
-	private static String lastMinuteTime = null;
-	private static LocalDateTime lastLocalDateTime = null;
-
-	private static LocalDateTime parseMicroUsingFullFormat(String yyMMddHHMMssSSSSSS) {
-		if (lastMinuteTime == null || !lastMinuteTime.regionMatches(0, yyMMddHHMMssSSSSSS, 0, 10)) {
-			String minPart = yyMMddHHMMssSSSSSS.substring(0, 10);
-			lastMinuteTime = minPart;
-			lastLocalDateTime = DTF_MIN.parse(minPart, LocalDateTime::from);
+	public ResizableDoubleArray getTimestamps(String from, String to) {
+		if ("process".equals(to)) {
+			if ("sending".equals(from)) {
+				return sendingToProcess;
+			} else if ("lastupdate".equals(from)) {
+				return lastUpdateToProcess;
+			} else if ("receive".equals(from)) {
+				return receiveToProcess;
+			} else if ("entry".equals(from)) {
+				return entryToProcess;
+			}
+		} else if ("sending".equals(to)) {
+			if ("lastupdate".equals(from)) {
+				return lastUpdateToSending;
+			} else if ("entry".equals(from)) {
+				return entryToSending;
+			}
+		} else if ("sending".equals(from) && "receive".equals(to)) {
+			return sendingToReceive;
 		}
-		long nanos = 1000L*Integer.parseInt(yyMMddHHMMssSSSSSS.substring(10));
-		return lastLocalDateTime.plusNanos(nanos);
+		throw new IllegalArgumentException("Latency from " + from + " to " + to + " not collected");
 	}
 
-	private static LocalDateTime parseMicroUsingShortFormat(String hhMMssSSSSSS, LocalDate localDate) {
-		if (lastMinuteTime == null || !lastMinuteTime.regionMatches(0, hhMMssSSSSSS, 0, 4)) {
-			String minPart = hhMMssSSSSSS.substring(0, 4);
-			lastMinuteTime = minPart;
-			lastLocalDateTime = LocalDateTime.of(localDate, TF_MIN.parse(minPart, LocalTime::from));
-		}
-		long nanos = 1000L*Integer.parseInt(hhMMssSSSSSS.substring(4));
-		return lastLocalDateTime.plusNanos(nanos);
+	private final int mode;
+	private final String filterInstrument;
+	private final int moexConsumerType;
+	private final File f;
+	private final LocalDate localDate;
+	private final String localDateStr;
+	private final long dateUtcOffsetNanos;
+
+	public ConsumerLatencyParser(String date, int mode, String filterInstrument, int moexConsumerType, File file) {
+		this.mode = mode;
+		this.filterInstrument = filterInstrument;
+		this.moexConsumerType = moexConsumerType;
+		this.localDate = LocalDate.parse(date, DateTimeFormatter.ofPattern("dd-MM-yyyy"));
+		this.f = file;
+		this.dateUtcOffsetNanos = localDate.atStartOfDay(UTC).toEpochSecond() * NANOS_IN_SECOND;
+		this.localDateStr = DateTimeFormatter.ofPattern("yyMMdd").format(this.localDate);
 	}
 
 	public static void main(String[] args) throws Exception {
@@ -60,6 +102,7 @@ public class ConsumerLatencyParser {
 		String date = args[2];
 		String csvPath = args.length > 3 ? args[3] : null;
 
+		final long st = System.currentTimeMillis();
 		System.out.println("Start " + directory + " : " + filePrefix + " : " + date + " : " + csvPath);
 
 		//24-02-2021
@@ -80,9 +123,6 @@ public class ConsumerLatencyParser {
 
 		String filterInstrument = args.length > 5 ? args[5] : null; //"1642954", "GAZP"
 
-		//try parsing the date
-		LocalDate localDate = LocalDate.parse(date, DateTimeFormatter.ofPattern("dd-MM-yyyy"));
-
 		if (!new File(directory).isDirectory()) {
 			throw new Exception("Invalid directory: " + directory);
 		}
@@ -95,60 +135,117 @@ public class ConsumerLatencyParser {
 		}
 
 		files = Arrays.stream(files)
-				.map(f -> new AbstractMap.SimpleEntry<>(f, fileIndex(f)))
+				.map(f -> {
+					String[] parts = f.getName().split("\\.");
+					return new AbstractMap.SimpleEntry<>(f, Integer.parseInt(parts[parts.length-3]));
+				})
 				.sorted(Map.Entry.comparingByValue())
 				.map(AbstractMap.SimpleEntry::getKey)
 				.toArray(File[]::new);
 
 		System.out.println("Files found: " + files.length + " in " + directory + " for " + date);
 
-		String loggerName = null;
-		{
-			String[] dirs = new File(directory).getAbsolutePath().split("/");
-			int indexOfLogs = lastIndexOf(dirs, "logs");
-			if (indexOfLogs < 1) {
-				throw new IllegalArgumentException("Unexpected directory: " + directory);
-			}
-			loggerName = dirs[indexOfLogs - 1];
-			System.out.println("consumer/logger name: " + loggerName);
+		String[] dirs = new File(directory).getAbsolutePath().split("/");
+		int indexOfLogs = Arrays.asList(dirs).lastIndexOf("logs");
+		if (indexOfLogs < 1) {
+			throw new IllegalArgumentException("Unexpected directory: " + directory);
+		}
+		String loggerName = dirs[indexOfLogs - 1];
+		System.out.println("consumer/logger name: " + loggerName);
+
+		final int consumerType;
+		if (loggerName.contains("hc_jdk") || loggerName.contains("fond")) {
+			consumerType = TYPE_FOND;
+		} else if (loggerName.contains("fx")) {
+			consumerType = TYPE_FX;
+		} else if (loggerName.contains("futures") || loggerName.contains("spectra")) {
+			consumerType = filePrefix.contains("index") ? TYPE_INDEX : TYPE_DERIVATIVES;
+		} else {
+			consumerType = 0;
+			System.err.println("Could not detect consumer type");
+		}
+		int ioParallelism = 1;
+		try {
+			ioParallelism = Integer.parseInt(System.getProperty("ioThreads", "1"));
+		} catch (Exception e) {
+			System.err.println("Could not parse ioThreads: number required. Single thread will be used");
+		}
+		int calcParallelism = 1;
+		try {
+			calcParallelism = Integer.parseInt(System.getProperty("calcThreads", "1"));
+		} catch (Exception e) {
+			System.err.println("Could not parse calcThreads: number required. Single thread will be used");
 		}
 
-		boolean is_futures = loggerName.contains("futures") || loggerName.contains("spectra");
-		boolean is_fond = loggerName.contains("hc_jdk") || loggerName.contains("fond");
-		boolean is_fx = loggerName.contains("fx");
-		boolean is_index = is_futures && filePrefix.contains("index");
+		final String effectiveDate = date;
+		final ConsumerLatencyParser[] tasks = parallelize(Arrays.stream(files)
+				.map(file -> new ConsumerLatencyParser(effectiveDate, mode, filterInstrument, consumerType, file))
+				.map(ConsumerLatencyParser::parse), ioParallelism)
+				.toArray(new ConsumerLatencyParser[0]);
+
+		if (mode <= 0) {
+			final long beforeCalculations = System.currentTimeMillis();
+			System.out.println("Spent on reading: " + (beforeCalculations - st) + " ms");
+			for (ConsumerLatencyParser task : tasks) {
+				task.compact();
+			}
+			writeCsvSummary(date, directory, filePrefix, csvPath, tasks, calcParallelism);
+			System.out.println("Spent on calculations: " + (System.currentTimeMillis() - beforeCalculations) + " ms");
+		} else {
+			System.out.println("Skip writing to file");
+		}
+
+		System.out.println("Completed");
+		System.out.println("Elapsed: " + (System.currentTimeMillis() - st) + " ms");
+	}
+
+	private static long parseTimeOffsetNanos(String hhMMssSSSSSS, int startIdx) {
+		int hour = (hhMMssSSSSSS.charAt(startIdx) - '0') * 10 + (hhMMssSSSSSS.charAt(startIdx + 1) - '0');
+		int minute = (hhMMssSSSSSS.charAt(startIdx + 2) - '0') * 10 + (hhMMssSSSSSS.charAt(startIdx + 3) - '0');
+		int acc = 0;
+		final int endIdx = startIdx + 12;
+		for (int i = startIdx + 4; i < endIdx; i++) {
+			acc = acc * 10 + hhMMssSSSSSS.charAt(i) - '0';
+		}
+		return (minute * 60L + hour * 3600L) * NANOS_IN_SECOND + acc * NANOS_IN_MICROS;
+	}
+
+	private long parseYYMMddHHMMssSSSSSS(String yyMMddHHMMssSSSSSS) {
+		if (localDateStr.regionMatches(0, yyMMddHHMMssSSSSSS, 0, 6)) {
+			return dateUtcOffsetNanos + parseTimeOffsetNanos(yyMMddHHMMssSSSSSS, 6);
+		} else {
+			final ZonedDateTime zonedDateTime = LocalDateTime.parse(yyMMddHHMMssSSSSSS, DTF_FULL).atZone(UTC);
+			final Instant instant = zonedDateTime.toInstant();
+			return instant.getEpochSecond() * NANOS_IN_SECOND + instant.getNano();
+		}
+	}
+
+	private long parseHHMMssSSSSSS(String hhMMssSSSSSS) {
+		return dateUtcOffsetNanos + parseTimeOffsetNanos(hhMMssSSSSSS, 0);
+	}
+
+	public ConsumerLatencyParser parse() {
+		System.out.println("== processing file " + f.getAbsolutePath() + " : " + f.length() + " ==");
 
 		//4*60 as of March 1, 2020 for futures and fx
-		int earlyStartMinute = LocalDate.parse(date, DateTimeFormatter.ofPattern("dd-MM-yyyy")).isBefore(LocalDate.parse("01-03-2021", DateTimeFormatter.ofPattern("dd-MM-yyyy"))) ? 7*60 : 4*60;
+		int earlyStartMinute = localDate.isBefore(LocalDate.of(2021, Month.MARCH, 1)) ? 7*60 : 4*60;
+		boolean lastUpdateTimeExists = true;
+		List<String> header = null;
+		int indexMsqSeqNum = -1;
+		int indexReceiveTime = -1;
+		int indexProcessTime = -1;
+		int indexSendingTime = -1;
+		int indexLastUpdateTime = -1;
+		int indexMDUpdateAction = -1;
+		int indexMDEntryType = -1;
+		int indexSymbol = -1;
+		int indexSecurityID = -1;
+		int indexRptSeq = -1;
+		int indexMDEntryDate = -1;
+		int indexMDEntryTime = -1;
+		int indexTradingSessionID = -1;
 
-		Map<ActionAndType, DescriptiveStatistics> sendingProcessDsMap = new TreeMap<>();
-		Map<ActionAndType, DescriptiveStatistics> lastUpdateProcessDsMap = new TreeMap<>();
-		Map<ActionAndType, DescriptiveStatistics> receiveProcessDsMap = new TreeMap<>();
-		Map<ActionAndType, DescriptiveStatistics> entryProcessDsMap = new TreeMap<>();
-		Map<ActionAndType, DescriptiveStatistics> lastUpdateSendingDsMap = new TreeMap<>();
-		Map<ActionAndType, DescriptiveStatistics> sendingReceiveDsMap = new TreeMap<>();
-		Map<ActionAndType, DescriptiveStatistics> entrySendingDsMap = new TreeMap<>();
-
-		for (File f : files) {
-
-			System.out.println("== processing file " + f.getAbsolutePath() + " : " + f.length() + " ==");
-
-			List<String> header = null;
-			int indexMsqSeqNum = -1;
-			int indexReceiveTime = -1;
-			int indexProcessTime = -1;
-			int indexSendingTime = -1;
-			int indexLastUpdateTime = -1;
-			int indexMDUpdateAction = -1;
-			int indexMDEntryType = -1;
-			int indexSymbol = -1;
-			int indexSecurityID = -1;
-			int indexRptSeq = -1;
-			int indexMDEntryDate = -1;
-			int indexMDEntryTime = -1;
-			int indexTradingSessionID = -1;
-
-			BufferedReader br = new BufferedReader(new InputStreamReader(new GZIPInputStream(new FileInputStream(f))));
+		try (BufferedReader br = new BufferedReader(new InputStreamReader(new GZIPInputStream(new FileInputStream(f))))) {
 
 			long startTime = System.currentTimeMillis();
 			long lastLogTime = System.currentTimeMillis();
@@ -161,7 +258,7 @@ public class ConsumerLatencyParser {
 				lineCount++;
 
 				if (System.currentTimeMillis() - lastLogTime > 10000) {
-					double msgPerSec = ((lineCount-lastLogCount)/(System.currentTimeMillis() - lastLogTime))*1000L;
+					double msgPerSec = ((lineCount - lastLogCount) / (System.currentTimeMillis() - lastLogTime)) * 1000L;
 					System.out.println("processing line " + lineCount + " : " + line + " : msg/sec: " + String.format("%.0f", msgPerSec));
 					lastLogTime = System.currentTimeMillis();
 					lastLogCount = lineCount;
@@ -183,6 +280,9 @@ public class ConsumerLatencyParser {
 					indexMDEntryDate = header.indexOf("MDEntryDate");
 					indexMDEntryTime = header.indexOf("MDEntryTime");
 					indexTradingSessionID = header.indexOf("TradingSessionID");
+					if (indexLastUpdateTime < 0) {
+						lastUpdateTimeExists = false;
+					}
 					continue;
 				}
 
@@ -192,7 +292,7 @@ public class ConsumerLatencyParser {
 				}
 
 				String[] sp = line.split(",", -1);
-				if (sp.length != header.size()){
+				if (sp.length != header.size()) {
 					System.err.println("Mismatch in columns: " + header.size() + " : " + sp.length + " : " + line);
 					continue;
 				}
@@ -207,9 +307,6 @@ public class ConsumerLatencyParser {
 					System.err.println("Invalid MDUpdateAction: " + line);
 					continue;
 				}
-
-				String entryType = sp[indexMDEntryType];
-				int updateAction = Integer.parseInt(sp[indexMDUpdateAction]);
 
 				if (filterInstrument != null) {
 					String symbol = sp[indexSymbol];
@@ -232,18 +329,15 @@ public class ConsumerLatencyParser {
 					}
 				}
 
-				LocalDateTime sendingTime = getSendingTime(sp, indexSendingTime, localDate);
+				long sendingTime = getSendingTime(sp, indexSendingTime);
+				int minutes_of_day = (int)((sendingTime % NANOS_IN_DAY) / NANOS_IN_MINUTE);
 
-				int minutes_of_day = sendingTime.getHour()*60 + sendingTime.getMinute();
-
-				if (is_futures && !is_index) {
-					if (minutes_of_day < earlyStartMinute || minutes_of_day >= 11*60 && minutes_of_day < 11*60+5 || minutes_of_day >= 15*60+45 && minutes_of_day < 16*60 || minutes_of_day >= 20*60+50) {
+				if (moexConsumerType == TYPE_DERIVATIVES) {
+					if (minutes_of_day < earlyStartMinute || minutes_of_day >= 11 * 60 && minutes_of_day < 11 * 60 + 5 || minutes_of_day >= 15 * 60 + 45 && minutes_of_day < 16 * 60 || minutes_of_day >= 20 * 60 + 50) {
 						continue;
 					}
-				}
-
-				if (is_index && indexSymbol >= 0) {
-					if (minutes_of_day < 7*60 || minutes_of_day >= 20*60+50 || minutes_of_day >= 15*60+40 && minutes_of_day < 16*60) {
+				} else if (moexConsumerType == TYPE_INDEX && indexSymbol >= 0) {
+					if (minutes_of_day < 7 * 60 || minutes_of_day >= 20 * 60 + 50 || minutes_of_day >= 15 * 60 + 40 && minutes_of_day < 16 * 60) {
 						continue;
 					}
 					String symbol = sp[indexSymbol];
@@ -258,38 +352,43 @@ public class ConsumerLatencyParser {
 							continue;
 						}
 					}
-				}
-
-				if (is_fond) {
+				} else if (moexConsumerType == TYPE_FOND) {
 					//if (minutes_of_day < 7*60 || minutes_of_day >= 15*60+40 && minutes_of_day < 16*60+5 || minutes_of_day >= 20*60+50) {
-					if (minutes_of_day < 7*60 || minutes_of_day >= 20*60+50) {
+					if (minutes_of_day < 7 * 60 || minutes_of_day >= 20 * 60 + 50) {
+						continue;
+					}
+				} else if (moexConsumerType == TYPE_FX) {
+					if (minutes_of_day < earlyStartMinute || minutes_of_day >= 20 * 60 + 50) {
 						continue;
 					}
 				}
 
-				if (is_fx) {
-					if (minutes_of_day < earlyStartMinute || minutes_of_day >= 20*60+50) {
-						continue;
-					}
-				}
-
-				LocalDateTime processTime = getTimeFromStandardFormat(sp, indexProcessTime, localDate);
-				LocalDateTime receiveTime = getTimeFromStandardFormat(sp, indexReceiveTime, localDate);
-				LocalDateTime lastUpdateTime = getTimeFromStandardFormat(sp, indexLastUpdateTime, localDate);
-				LocalDateTime entryTime = getEntryTime(sp, indexMDEntryDate, indexMDEntryTime, localDate);
+				final long processTime = getTimeFromStandardFormat(sp, indexProcessTime);
+				final long receiveTime = getTimeFromStandardFormat(sp, indexReceiveTime);
+				final long entryTime = getEntryTime(sp, indexMDEntryDate, indexMDEntryTime);
+				final long lastUpdateTime = getTimeFromStandardFormat(sp, indexLastUpdateTime);
 
 				if (mode >= 1) {
 					//only read and parse
 					continue;
 				}
 
-				addInterval(sendingTime, processTime, updateAction, entryType, sendingProcessDsMap);
-				addInterval(lastUpdateTime, processTime, updateAction, entryType, lastUpdateProcessDsMap);
-				addInterval(receiveTime, processTime, updateAction, entryType, receiveProcessDsMap);
-				addInterval(entryTime, processTime, updateAction, entryType, entryProcessDsMap);
-				addInterval(lastUpdateTime, sendingTime, updateAction, entryType, lastUpdateSendingDsMap);
-				addInterval(entryTime, sendingTime, updateAction, entryType, entrySendingDsMap);
-				addInterval(sendingTime, receiveTime, updateAction, entryType, sendingReceiveDsMap);
+				addLatency(sendingToProcess, sendingTime, processTime);
+				addLatency(receiveToProcess, receiveTime, processTime);
+				addLatency(entryToProcess, entryTime, processTime);
+				addLatency(sendingToReceive, sendingTime, receiveTime);
+				addLatency(entryToSending, entryTime, sendingTime);
+				if (lastUpdateTimeExists) {
+					addLatency(lastUpdateToProcess, lastUpdateTime, processTime);
+					addLatency(lastUpdateToSending, lastUpdateTime, sendingTime);
+				}
+				byte entryType = toByte(sp[indexMDEntryType], "MDEntryType");
+				int updateActionValue = toByte(sp[indexMDUpdateAction], "MDUpdateAction") - '0';
+				actions.add((byte)updateActionValue);
+				sets.uniqueActions.add(updateActionValue);
+				types.add(entryType);
+				sets.uniqueTypes.add(entryType);
+				sets.uniqueActionTypeCombinations.add(entryType + 128 * updateActionValue);
 
 				/*
 				if (entryTime != null) {
@@ -308,95 +407,240 @@ public class ConsumerLatencyParser {
 				*/
 
 			} while ((line = br.readLine()) != null);
-
-			br.close();
-
-			System.out.println("processed file. lines: " + lineCount + " in " + (System.currentTimeMillis()-startTime));
-
+			System.out.println("processed file. lines: " + lineCount + " in " + (System.currentTimeMillis()-startTime) + " ms");
+		} catch (IOException e) {
+			throw new UncheckedIOException(e);
 		}
 
-		if (mode <= 0) {
+		return this;
+	}
 
-			List<String> cmds = new ArrayList<String>();
-			cmds.addAll(toCSV(date, "entry", "sending", loggerName, filePrefix, entrySendingDsMap));
-			cmds.addAll(toCSV(date, "lastupdate", "sending", loggerName, filePrefix, lastUpdateSendingDsMap));
-			cmds.addAll(toCSV(date, "sending", "receive", loggerName, filePrefix, sendingReceiveDsMap));
-			cmds.addAll(toCSV(date, "receive", "process", loggerName, filePrefix, receiveProcessDsMap));
-			cmds.addAll(toCSV(date, "entry", "process", loggerName, filePrefix, entryProcessDsMap));
-			cmds.addAll(toCSV(date, "lastupdate", "process", loggerName, filePrefix, lastUpdateProcessDsMap));
-			cmds.addAll(toCSV(date, "sending", "process", loggerName, filePrefix, sendingProcessDsMap));
+	private void compact() {
+		if ((actions.internalArray.length - actions.numElements) / (1.0 * actions.numElements) > 0.1) {
+			actions.contract();
+			types.contract();
+			sendingToProcess.contract();
+			sendingToProcess.contract();
+			lastUpdateToProcess.contract();
+			receiveToProcess.contract();
+			entryToProcess.contract();
+			lastUpdateToSending.contract();
+			sendingToReceive.contract();
+			entryToSending.contract();
+		}
+	}
 
-			String csvHeader = "date,directory,file,from,to,action,type,count,min,p0.1,p1,p5,p10,p25,p50,p75,p90,p95,p99,p99.9,max";
-			//System.out.println(csvHeader);
-			for (String cmd : cmds) {
-				//System.out.println(cmd);
-			}
-
-			System.out.println("Write to file: " + csvPath + " records: " + cmds.size());
-
-			if (csvPath != null) {
-				BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(new File(csvPath))));
-				bw.write(csvHeader + "\n");
-				for (String cmd : cmds) {
-					bw.write(cmd + "\n");
-				}
-				bw.close();
-			}
+	private void addLatency(ResizableDoubleArray array, long fromNanos, long toNanos) {
+		if (fromNanos == Long.MIN_VALUE || toNanos == Long.MIN_VALUE) {
+			array.addElement(Double.NaN);
 		} else {
-			System.out.println("Skip writing to file");
+			array.addElement((toNanos - fromNanos) / (double)NANOS_IN_MICROS);
 		}
-
-		System.out.println("Completed");
-
 	}
 
-	private static <T> int lastIndexOf(T[] array, T element) {
-		for (int i = array.length - 1; i >= 0; i--) {
-			if (element.equals(array[i])) {
-				return i;
+	private static void writeCsvSummary(String date, String directory, String filePrefix, String csvPath, ConsumerLatencyParser[] data, int parallelismLevel) throws IOException {
+		if (parallelismLevel <= 0 || parallelismLevel == ForkJoinPool.getCommonPoolParallelism()) {
+			parallelismLevel = 0;
+		}
+		final SetsContainer mergedSets = SetsContainer.merged(Arrays.stream(data).map(d -> d.sets).toArray(SetsContainer[]::new));
+		final int totalValues = Arrays.stream(data).mapToInt(d -> d.actions.numElements).sum();
+		System.out.println("Sample count: " + totalValues);
+		System.out.printf("Memory consumed total: %.1f MB, per metric: %.1f MB%n", (7 * 8L + 2) * totalValues / 1024.0 / 1024.0, 8L * totalValues / 1024.0 / 1024.0);
+		final Stream<String> stream = Stream.of(
+				Pair.create("entry", "sending"),
+				Pair.create("lastupdate", "sending"),
+				Pair.create("sending", "receive"),
+				Pair.create("receive", "process"),
+				Pair.create("entry", "process"),
+				Pair.create("lastupdate", "process"),
+				Pair.create("sending", "process")
+		)
+				.flatMap(pair -> calculateStatistics(pair.getFirst(), pair.getSecond(), data, mergedSets, totalValues).entrySet().stream())
+				.sorted(Comparator.comparing((Map.Entry<StatisticsMetadata, Supplier<Map<String, Double>>> a) -> a.getKey().mdUpdateAction)
+						.thenComparing(b -> b.getKey().mdEntryType)
+						.thenComparing(a -> a.getKey().from)
+						.thenComparing(a -> a.getKey().to))
+				.map(e -> new AbstractMap.SimpleEntry<>(e.getKey(), e.getValue().get()))
+				.filter(e -> e.getValue() != null)
+				.sorted(Comparator.comparing((Map.Entry<StatisticsMetadata, Map<String, Double>> a) -> a.getKey().from)
+						.thenComparing(b -> b.getKey().to)
+						.thenComparing(a -> a.getKey().mdUpdateAction)
+						.thenComparing(a -> a.getKey().mdEntryType))
+				.map(e -> toCSVRow(date, directory, filePrefix, e.getKey(), e.getValue()));
+		final List<String> cmds = parallelize(stream, parallelismLevel);
+
+		String csvHeader = "date,directory,file,from,to,action,type," + String.join(",", STATISTICS_CALCULATORS.keySet());
+		//System.out.println(csvHeader);
+		//for (String cmd : cmds) {
+		//System.out.println(cmd);
+		//}
+
+		System.out.println("Write to file: " + csvPath + " records: " + cmds.size());
+
+		if (csvPath != null) {
+			try (BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(csvPath)))) {
+				bw.write(csvHeader);
+				bw.write('\n');
+				for (String cmd : cmds) {
+					bw.write(cmd);
+					bw.write('\n');
+				}
 			}
 		}
-		return -1;
 	}
 
-	public static List<String> toCSV(String date, String from, String to, String directory, String filePrefix, Map<ActionAndType, DescriptiveStatistics> ds) {
-		List<String> res = new ArrayList<>();
-		StringBuilder row = new StringBuilder();
-		for (Map.Entry<ActionAndType, DescriptiveStatistics> me : ds.entrySet()) {
-			row.setLength(0);
-			row.append(date).append(',').append(directory)
+	private static <T> List<T> parallelize(Stream<T> originalStream, int parallelism) {
+		final Stream<T> stream = parallelism == 1 ? originalStream : originalStream.parallel();
+		if (parallelism <= 1) {
+			return stream.collect(Collectors.toList());
+		} else {
+			final ForkJoinPool pool = new ForkJoinPool(parallelism);
+			try {
+				return pool.submit(() -> stream.collect(Collectors.toList())).get();
+			} catch (Exception e) {
+				throw new IllegalStateException(e);
+			} finally {
+				pool.shutdown();
+			}
+		}
+	}
+
+	private static byte toByte(String value, String type) {
+		if (value.length() == 1) {
+			return (byte)value.charAt(0);
+		} else if (value.isEmpty()) {
+			return 0;
+		}
+		throw new IllegalStateException("Illegal " + type + " value: " + value);
+	}
+
+	private static Map<StatisticsMetadata, Supplier<Map<String, Double>>> calculateStatistics(String fromStr, String toStr, ConsumerLatencyParser[] data, SetsContainer mergedSets, int totalValues) {
+		final long calculateStartTime = System.currentTimeMillis();
+		final ResizableDoubleArray latenciesAll = filter(fromStr, toStr, totalValues, c -> i -> true, data);
+		if (latenciesAll == null) {
+			return Collections.emptyMap();
+		}
+		final Map<StatisticsMetadata, Supplier<Map<String, Double>>> result = new LinkedHashMap<>();
+		final Supplier<Map<String, Double>> all = () -> {
+			final LinkedHashMap<String, Double> allStat = calculateStatistics(latenciesAll);
+			System.out.printf("Calculated latency for %s -> %s MDEntryType=all, MDUpdateAction=all in %s ms%n", fromStr, toStr, System.currentTimeMillis() - calculateStartTime);
+			return allStat;
+		};
+		result.put(new StatisticsMetadata(fromStr, toStr, "", ""), all);
+		if (mergedSets.uniqueActions.size() == 1) {
+			final int action = mergedSets.uniqueActions.getValues().keySet().iterator().next();
+			System.out.printf("Skipped per-action latency calculations %s -> %s: single action=%s found%n", fromStr, toStr, action);
+			result.put(new StatisticsMetadata(fromStr, toStr, "", Integer.toString(action)), all);
+		} else {
+			for (Map.Entry<Integer, Integer> actionAndCount : mergedSets.uniqueActions.getValues().entrySet()) {
+				final int action = actionAndCount.getKey();
+				final Supplier<Map<String, Double>> byAction = () -> {
+					final long st = System.currentTimeMillis();
+					final ResizableDoubleArray latenciesPerAction = filter(fromStr, toStr, actionAndCount.getValue(), c -> i -> c.actions.get(i) == action, data);
+					if (latenciesPerAction != null) {
+						final LinkedHashMap<String, Double> perAction = calculateStatistics(latenciesPerAction);
+						System.out.printf("Calculated latency for %s -> %s MDEntryType=all, MDUpdateAction=%s in %s ms%n", fromStr, toStr, action, System.currentTimeMillis() - st);
+						return perAction;
+					}
+					return null;
+				};
+				result.put(new StatisticsMetadata(fromStr, toStr, "", Integer.toString(actionAndCount.getKey())), byAction);
+			}
+		}
+		if (mergedSets.uniqueTypes.size() == 1) {
+			final char type = (char) mergedSets.uniqueTypes.getValues().keySet().iterator().next().intValue();
+			System.out.printf("Skipped per-type latency calculations for %s -> %s: single MDEntryType=%s found%n", fromStr, toStr, type);
+			result.put(new StatisticsMetadata(fromStr, toStr, Character.toString(type), ""), all);
+		} else {
+			for (Map.Entry<Integer, Integer> typeAndCount : mergedSets.uniqueTypes.getValues().entrySet()) {
+				final int type = typeAndCount.getKey();
+				char typeAsChar = (char) type;
+				final Supplier<Map<String, Double>> byType = () -> {
+					final long st = System.currentTimeMillis();
+					final ResizableDoubleArray latenciesPerType = filter(fromStr, toStr, typeAndCount.getValue(), c -> i -> c.types.get(i) == type, data);
+					if (latenciesPerType != null) {
+						final LinkedHashMap<String, Double> perType = calculateStatistics(latenciesPerType);
+						System.out.printf("Calculated latency for %s -> %s MDEntryType=%s, MDUpdateAction=all in %s ms%n", fromStr, toStr, typeAsChar, System.currentTimeMillis() - st);
+						return perType;
+					}
+					return null;
+				};
+				result.put(new StatisticsMetadata(fromStr, toStr, Character.toString(typeAsChar), ""), byType);
+			}
+		}
+		if (mergedSets.uniqueActionTypeCombinations.size() == 1) {
+			final char type = (char)mergedSets.uniqueTypes.getValues().keySet().iterator().next().intValue();
+			final int action = mergedSets.uniqueActions.getValues().keySet().iterator().next();
+			System.out.printf("Skipped per-combination latency calculations for %s -> %s: single combination of MDEntryType=%s and MDUpdateAction=%s found%n", fromStr, toStr, type, action);
+			result.put(new StatisticsMetadata(fromStr, toStr, Character.toString(type), Integer.toString(action)), all);
+		} else {
+			for (Map.Entry<Integer, Integer> cmbToCount : mergedSets.uniqueActionTypeCombinations.getValues().entrySet()) {
+				int cmb = cmbToCount.getKey();
+				char typeAsChar = (char) (cmb % 128);
+				int action = cmb / 128;
+				final Supplier<Map<String, Double>> byActionAndType = () -> {
+					final long st = System.currentTimeMillis();
+					final ResizableDoubleArray latenciesPerCombo = filter(fromStr, toStr, cmbToCount.getValue(), c -> i -> c.types.get(i) + c.actions.get(i) * 128 == cmb, data);
+					if (latenciesPerCombo != null) {
+						final LinkedHashMap<String, Double> perCombo = calculateStatistics(latenciesPerCombo);
+						System.out.printf("Calculated latency for %s -> %s MDEntryType=%s, MDUpdateAction=%s in %s ms%n", fromStr, toStr, typeAsChar, action, System.currentTimeMillis() - st);
+						return perCombo;
+					}
+					return null;
+				};
+				result.put(new StatisticsMetadata(fromStr, toStr, Character.toString(typeAsChar), Integer.toString(action)), byActionAndType);
+			}
+		}
+		return result;
+	}
+
+	private static ResizableDoubleArray filter(String from, String to, int size, Function<ConsumerLatencyParser, IntPredicate> indexPredicateFactory, ConsumerLatencyParser[] data) {
+		if (size == 0) {
+			return null;
+		}
+		final ResizableDoubleArray latencies = new ResizableDoubleArray(size);
+		for (ConsumerLatencyParser container : data) {
+			final IntPredicate indexPredicate = indexPredicateFactory.apply(container);
+			final ResizableDoubleArray source = container.getTimestamps(from, to);
+			final int len = source.getNumElements();
+			final double[] array = source.getInternalValues();
+			for (int i = 0; i < len; i++) {
+				final double element = array[i];
+				if (Double.isNaN(element) || !indexPredicate.test(i)) {
+					continue;
+				}
+				latencies.addElement(element);
+			}
+		}
+		return latencies.getNumElements() == 0 ? null : latencies;
+	}
+
+
+	private static LinkedHashMap<String, Double> calculateStatistics(ResizableDoubleArray latencies) {
+		return STATISTICS_CALCULATORS.entrySet().stream()
+				.collect(Collectors.toMap(Map.Entry::getKey,
+						e -> e.getValue().applyAsDouble(latencies),
+						(a, b) -> b,
+						LinkedHashMap::new));
+	}
+
+	public static String toCSVRow(String date, String directory, String filePrefix, StatisticsMetadata meta, Map<String, Double> values) {
+		StringBuilder row = new StringBuilder()
+				.append(date).append(',').append(directory)
 				.append(',').append(filePrefix)
-				.append(',').append(from)
-				.append(',').append(to).append(',');
-			if (me.getKey().action >= 0) {
-				row.append(me.getKey().action);
-			}
+				.append(',').append(meta.from)
+				.append(',').append(meta.to).append(',')
+				.append(meta.mdUpdateAction).append(',')
+				.append(meta.mdEntryType);
+		for (Map.Entry<String, Double> entry : values.entrySet()) {
 			row.append(',');
-			if (me.getKey().type != null) {
-				row.append(me.getKey().type);
+			if ("count".equals(entry.getKey())) {
+				row.append(entry.getValue().longValue());
+			} else {
+				row.append(String.format("%.0f", entry.getValue()));
 			}
-			DescriptiveStatistics d = me.getValue();
-			row.append(",").append(d.getN());
-			row.append(",").append(String.format("%.0f", d.getMin()));
-			double[] ranks = {0.1, 1.0, 5.0, 10.0, 25.0, 50.0, 75.0, 90.0, 95.0, 99.0, 99.9};
-			for (double rank : ranks) {
-				row.append(',').append(String.format("%.0f", d.getPercentile(rank)));
-			}
-			row.append(',').append(String.format("%.0f", d.getMax()));
-			res.add(row.toString());
 		}
-		return res;
-	}
-
-	public static void addInterval(LocalDateTime from, LocalDateTime to, int action, String type, Map<ActionAndType, DescriptiveStatistics> dsMap) {
-		if (to == null || from == null) {
-			return;
-		}
-		long interval_micros = ChronoUnit.MICROS.between(from, to);
-		dsMap.computeIfAbsent(ActionAndType.ofNone(), k -> new DescriptiveStatistics()).addValue(interval_micros);
-		dsMap.computeIfAbsent(ActionAndType.ofAction(action), k -> new DescriptiveStatistics()).addValue(interval_micros);
-		dsMap.computeIfAbsent(ActionAndType.ofType(type), k -> new DescriptiveStatistics()).addValue(interval_micros);
-		dsMap.computeIfAbsent(ActionAndType.ofActionAndType(action, type), k -> new DescriptiveStatistics()).addValue(interval_micros);
+		return row.toString();
 	}
 
 	private static final DateTimeFormatter TF_SEC = DateTimeFormatter.ofPattern("HHmmss");
@@ -404,66 +648,51 @@ public class ConsumerLatencyParser {
 	private static final DateTimeFormatter TF_MICRO = DateTimeFormatter.ofPattern("HHmmssSSSSSS");
 	private static final DateTimeFormatter TF_NANO = DateTimeFormatter.ofPattern("HHmmssSSSSSSSSS");
 
-	public static LocalDateTime getTimeFromStandardFormat(String[] sp, int idx, LocalDate date) {
-		if (idx < 0) {
-			return null;
-		}
-		String str = sp[idx];
-
-		if (str.isEmpty()) {
-			return null;
+	// In opposite to getSendingTime method, return Long.MIN_VALUE instead of exception in case of empty value
+	private long getTimeFromStandardFormat(String[] sp, int idx) {
+		String str;
+		if (idx < 0 || (str = sp[idx]).isEmpty()) {
+			return Long.MIN_VALUE;
 		}
 		if (str.length() == 12) {
-			return parseMicroUsingShortFormat(str, date);
+			return parseHHMMssSSSSSS(str);
 		}
-		return parseMicroUsingFullFormat(str);
+		return parseYYMMddHHMMssSSSSSS(str);
 	}
 
-	public static LocalDateTime getSendingTime(String[] sp, int idx, LocalDate date) {
-		if (idx < 0) {
-			return null;
-		}
-		String str = sp[idx];
-		if (str.isEmpty()) {
-			return null;
+	private long getSendingTime(String[] sp, int idx) {
+		String str;
+		if (idx < 0 || (str = sp[idx]).isEmpty()) {
+			throw new IllegalStateException("SendingTime must be specified");
 		}
 		switch (str.length()) {
-			case 18: return parseMicroUsingFullFormat(str);
-			case 17: return LocalDateTime.of(date, LocalTime.parse(str.substring(8), TF_MILLI));
-			case 12: return parseMicroUsingShortFormat(str, date);
+			case 18: return parseYYMMddHHMMssSSSSSS(str);
+			case 17: return LocalTime.parse(str.substring(8), TF_MILLI).toNanoOfDay() + dateUtcOffsetNanos;
+			case 12: return parseHHMMssSSSSSS(str);
 			default: throw new RuntimeException("Unexpected sendingTime " + str);
 		}
 	}
 
-	public static LocalDateTime getEntryTime(String[] sp, int indexDate, int indexTime, LocalDate localDate) {
-		if (indexTime < 0) {
-			return null;
+	private long getEntryTime(String[] sp, int indexDate, int indexTime) {
+		String timeStr;
+		if (indexTime < 0 || (timeStr = sp[indexTime]).isEmpty() || !sp[indexDate].isEmpty()) {
+			return Long.MIN_VALUE;
 		}
-		String timeStr = sp[indexTime];
-		if (timeStr.isEmpty()) {
-			return null;
-		}
-		String dateStr = sp[indexDate];
-		if (!dateStr.isEmpty()) { // previous day
-			return null;
-		}
-
-		//avoid string format for perf
 		int tlen = timeStr.length();
-		DateTimeFormatter df = null;
+		final DateTimeFormatter df;
 		if (tlen <= 6) {
 			df = TF_SEC;
-			timeStr = String.format("%06d", Long.parseLong(timeStr));
+			//timeStr = String.format("%06d", Long.parseLong(timeStr));
 			//second-level precision doesn't make sense for latency monitoring
-			return null;
+			return Long.MIN_VALUE;
 		} else if (tlen == 11) {
 			// 70958834009 > 070958834009
 			timeStr = "0" + timeStr;
 			df = TF_MICRO;
-			return parseMicroUsingShortFormat(timeStr, localDate);
+			return parseHHMMssSSSSSS(timeStr);
 		} else if (tlen == 12) {
 			df = TF_MICRO;
-			return parseMicroUsingShortFormat(timeStr, localDate);
+			return parseHHMMssSSSSSS(timeStr);
 		} else if (tlen == 14) {
 			timeStr = "0" + timeStr;
 			df = TF_NANO;
@@ -472,73 +701,136 @@ public class ConsumerLatencyParser {
 		} else {
 			throw new RuntimeException("Unexpected time string: " + timeStr);
 		}
-		return LocalDateTime.of(localDate, LocalTime.parse(timeStr, df));
-
+		return LocalTime.parse(timeStr, df).toNanoOfDay() + dateUtcOffsetNanos;
 	}
 
-	private static final class ActionAndType implements Comparable<ActionAndType> {
-		private final int action;
-		private final String type;
-		private String str;
+	private static final class StatisticsMetadata {
+		private final String from;
+		private final String to;
+		private final String mdEntryType;
+		private final String mdUpdateAction;
 
-		private static ActionAndType ofType(String type) {
-			return new ActionAndType(-1, type);
+		private StatisticsMetadata(String from, String to, String mdEntryType, String mdUpdateAction) {
+			this.from = from;
+			this.to = to;
+			this.mdEntryType = mdEntryType;
+			this.mdUpdateAction = mdUpdateAction;
+		}
+	}
+
+	private static final class SetsContainer {
+		private final SimpleIntMultiSet uniqueActions;
+		private final SimpleIntMultiSet uniqueTypes;
+		private final SimpleIntMultiSet uniqueActionTypeCombinations;
+
+		private SetsContainer() {
+			this(new SimpleIntMultiSet(3), new SimpleIntMultiSet(128), new SimpleIntMultiSet(128 * 3));
 		}
 
-		private static ActionAndType ofAction(int action) {
-			return new ActionAndType(action, null);
+		private SetsContainer(SimpleIntMultiSet uniqueActions, SimpleIntMultiSet uniqueTypes, SimpleIntMultiSet uniqueActionTypeCombinations) {
+			this.uniqueActions = uniqueActions;
+			this.uniqueTypes = uniqueTypes;
+			this.uniqueActionTypeCombinations = uniqueActionTypeCombinations;
 		}
 
-		private static ActionAndType ofActionAndType(int action, String type) {
-			return new ActionAndType(action, type);
+		public static SetsContainer merged(SetsContainer[] containers) {
+			return new SetsContainer(
+					SimpleIntMultiSet.merge(Arrays.stream(containers).map(c -> c.uniqueActions).toArray(SimpleIntMultiSet[]::new)),
+					SimpleIntMultiSet.merge(Arrays.stream(containers).map(c -> c.uniqueTypes).toArray(SimpleIntMultiSet[]::new)),
+					SimpleIntMultiSet.merge(Arrays.stream(containers).map(c -> c.uniqueActionTypeCombinations).toArray(SimpleIntMultiSet[]::new))
+			);
+		}
+	}
+
+	private static final class SimpleIntMultiSet {
+		private final int[] data;
+		private int size;
+
+		public SimpleIntMultiSet(int maxSize) {
+			data = new int[maxSize];
 		}
 
-		private static ActionAndType ofNone() {
-			return new ActionAndType(-1, null);
-		}
-
-		private ActionAndType(int action, String type) {
-			this.action = action;
-			this.type = type;
-		}
-
-		@Override
-		public String toString() {
-			if (str == null) {
-				StringBuilder sb = new StringBuilder().append('{');
-				if (action != -1) {
-					sb.append("action=").append(action);
-				}
-				if (type != null) {
-					if (sb.length() > 1) {
-						sb.append(", ");
+		public static SimpleIntMultiSet merge(SimpleIntMultiSet[] sets) {
+			int length = Arrays.stream(sets).mapToInt(s -> s.data.length).max().orElse(0);
+			final SimpleIntMultiSet merged = new SimpleIntMultiSet(length);
+			for (int i = 0; i < length; i++) {
+				int cnt = 0;
+				for (SimpleIntMultiSet set : sets) {
+					if (set.data.length > i) {
+						cnt += set.data[i];
 					}
-					sb.append("type=").append(type);
 				}
-				sb.append('}');
-				str = sb.toString();
+				if (cnt > 0) {
+					merged.data[i] = cnt;
+					merged.size++;
+				}
 			}
-			return str;
+			return merged;
 		}
 
-		private int size() {
-			int size = 0;
-			if (action != -1) {
+		public void add(int c) {
+			final int oldLength = data[c];
+			data[c] = oldLength + 1;
+			if (oldLength == 0) {
 				size++;
 			}
-			if (type != null) {
-				size++;
+		}
+
+		public Map<Integer, Integer> getValues() {
+			Map<Integer, Integer> result = new LinkedHashMap<>();
+			if (size > 0) {
+				for (int i = 0; i < data.length; i++) {
+					if (data[i] > 0) {
+						result.put(i, data[i]);
+					}
+				}
 			}
+			return result;
+		}
+
+		public int size() {
 			return size;
 		}
+	}
 
-		@Override
-		public int compareTo(ActionAndType o) {
-			int cmp = Integer.compare(size(), o.size());
-			if (cmp == 0) {
-				cmp = toString().compareTo(o.toString());
+	private static final class ResizableByteArray {
+		private final double expansionFactor = 2.0;
+		private byte[] internalArray;
+		private int numElements;
+
+		public ResizableByteArray(int initialCapacity) {
+			if (initialCapacity <= 0) {
+				throw new IllegalArgumentException("Initial capacity must be positive");
 			}
-			return cmp;
+			this.internalArray = new byte[initialCapacity];
+		}
+
+		public void contract() {
+			this.internalArray = Arrays.copyOf(internalArray, numElements + 1);
+		}
+
+		public void add(byte value) {
+			if (this.internalArray.length <= this.numElements) {
+				this.expand();
+			}
+			this.internalArray[this.numElements++] = value;
+		}
+
+		private void expand() {
+			final int oldLength = internalArray.length;
+			long newSize = (long) FastMath.ceil((double)this.internalArray.length * this.expansionFactor);;
+			if (newSize > Integer.MAX_VALUE - 2) {
+				if (oldLength < Integer.MAX_VALUE - 2) {
+					newSize = Integer.MAX_VALUE - 2;
+				} else {
+					throw new OutOfMemoryError("Cannot allocate memory for " + (Integer.MAX_VALUE - 1) + " elements");
+				}
+			}
+			this.internalArray = Arrays.copyOf(internalArray, (int)newSize);
+		}
+
+		public byte get(int index) {
+			return this.internalArray[index];
 		}
 	}
 }

--- a/finance/ru/ConsumerLatencyParser.java
+++ b/finance/ru/ConsumerLatencyParser.java
@@ -549,7 +549,7 @@ public class ConsumerLatencyParser {
 	private static Map<StatisticsMetadata, Supplier<Map<String, Double>>> calculateStatistics(String fromStr, String toStr, ConsumerLatencyParser data) {
 		final long calculateStartTime = System.currentTimeMillis();
 		final ResizableDoubleArray array = data.getTimestamps(fromStr, toStr);
-		final ResizableDoubleArray latenciesAll = Arrays.stream(array.getInternalValues())
+		final ResizableDoubleArray latenciesAll = array.getNumElements() == 0 || Arrays.stream(array.getInternalValues())
 				.limit(array.getNumElements())
 				.anyMatch(Double::isNaN) ? filter(array, array.getNumElements(), i -> true) : array;
 		if (latenciesAll == null) {


### PR DESCRIPTION
Resolves [#165](https://github.com/axibase/moex-consumer/issues/165)

This version consumes twice less memory and allows to parallelize parsing and calculation. Parsing parallelization is performed on file level, calculation – on series level. Use `-DioThreads=N` and `-DcalcThreads=N` to control how many threads to be assigned to which task. Default is 1. Use `0` to use `ForkJoinPool.commonPool()` and assign work to all available threads.
After parsing stage, total number of samples, total memory consumed on data in MBs, and memory consumed for 1 metric, are reported.

On DMA, all logs but logger_hc_jdk:statistics are processed in parallel with `-Xmx=4G`, stock market statistics – `-Xmx=6G` with parallel parse, single-thread calculate.