### PR TITLE
SQL docs updated

### DIFF
--- a/finance/ru/sql.md
+++ b/finance/ru/sql.md
@@ -977,7 +977,7 @@ Period is a repeating time interval used to group values occurred within each in
 Period syntax:
 
 ```sql
-GROUP BY PERIOD(int count varchar unit [, timezone])
+GROUP BY PERIOD(time_interval [, timezone])
 ```
 
 * `timezone` = [Time Zone ID](../../shared/timezone-list.md) as literal string, or `entity.timeZone`/`metric.timeZone` column.
@@ -1518,11 +1518,7 @@ date_parse('31.01.2017 12:36:03.283 Europe/Berlin', 'dd.MM.yyyy HH:mm:ss.SSS ZZZ
 The function rounds the input date to the start of the containing calendar period. The date can be specified as literal date, Unix time in milliseconds or a [calendar expression](../../shared/calendar.md#keywords).
 
 ```javascript
-date_round(varchar date | bigint time, int count varchar unit)
-```
-
-```javascript
-date_round(calendar_expression, int count varchar unit)
+date_round(varchar date | bigint time | calendar_expression, time_interval)
 ```
 
 ```sql
@@ -1957,7 +1953,7 @@ Function | Description
 The `LAG` function provides access to a preceding row at a specified offset from the current position.
 
 ```javascript
-LAG(varchar columnName [, integer offset [, defaultValue]])
+LAG(scalar_expression [, integer offset [, defaultValue]])
 ```
 
 Example:
@@ -1999,7 +1995,7 @@ The `LAG` function in the `SELECT` expression is applied to the filtered result 
 The `LEAD` function provides access to a following row at a specified offset from the current position.
 
 ```javascript
-LEAD(varchar columnName [, integer offset [, defaultValue]])
+LEAD(scalar_expression [, integer offset [, defaultValue]])
 ```
 
 Example:
@@ -2020,7 +2016,7 @@ The `LEAD` function operates similarly to the [`LAG`](#lag) function except that
 The `FIRST_VALUE` is an analytical function that returns the first row within the partition.
 
 ```javascript
-FIRST_VALUE(varchar columnName)
+FIRST_VALUE(scalar_expression)
 ```
 
 Example:

--- a/finance/sql.md
+++ b/finance/sql.md
@@ -962,7 +962,7 @@ Period is a repeating time interval used to group values occurred within each in
 Period syntax:
 
 ```sql
-GROUP BY PERIOD(int count varchar unit [, timezone])
+GROUP BY PERIOD(time_interval [, timezone])
 ```
 
 * `timezone` = [Time Zone ID](../shared/timezone-list.md) as literal string, or `entity.timeZone`/`metric.timeZone` column.
@@ -1499,11 +1499,7 @@ date_parse('31.01.2017 12:36:03.283 Europe/Berlin', 'dd.MM.yyyy HH:mm:ss.SSS ZZZ
 The function rounds the input date to the start of the containing calendar period. The date can be specified as literal date, Unix time in milliseconds or a [calendar expression](../shared/calendar.md#keywords).
 
 ```javascript
-date_round(varchar date | bigint time, int count varchar unit)
-```
-
-```javascript
-date_round(calendar_expression, int count varchar unit)
+date_round(varchar date | bigint time | calendar_expression, time_interval)
 ```
 
 ```sql
@@ -1939,7 +1935,7 @@ Function | Description
 The `LAG` function provides access to a preceding row at a specified offset from the current position.
 
 ```javascript
-LAG(varchar columnName [, integer offset [, defaultValue]])
+LAG(scalar_expression [, integer offset [, defaultValue]])
 ```
 
 Example:
@@ -1980,7 +1976,7 @@ The `LAG` function in the `SELECT` expression is applied to the filtered result 
 The `LEAD` function provides access to a following row at a specified offset from the current position.
 
 ```javascript
-LEAD(varchar columnName [, integer offset [, defaultValue]])
+LEAD(scalar_expression [, integer offset [, defaultValue]])
 ```
 
 Example:
@@ -2001,7 +1997,7 @@ The `LEAD` function operates similarly to the [`LAG`](#lag) function except that
 The `FIRST_VALUE` is an analytical function that returns the first row within the partition.
 
 ```javascript
-FIRST_VALUE(varchar columnName)
+FIRST_VALUE(scalar_expression)
 ```
 
 Example:

--- a/sql/README.md
+++ b/sql/README.md
@@ -1510,7 +1510,7 @@ Period is a repeating time interval used to group values occurred within each in
 Period syntax:
 
 ```sql
-GROUP BY PERIOD(int count varchar unit [, option])
+GROUP BY PERIOD(time_interval [, option])
 ```
 
 `option` = `interpolate` | `align` | `extend` | `timezone`
@@ -1929,7 +1929,7 @@ Example | Description
 | `MIN` | Minimum of values. | `MIN(value)` |
 | `MAX` | Maximum of values. | `MAX(value)` |
 | `AVG` | Average of values. | `AVG(value)` |
-| `PRODUCT` | Product of values. | `PRODUCT(values)` |
+| `PRODUCT` | Product of values. | `PRODUCT(value)` |
 | `WAVG` | [Weighted average](../api/data/series/smooth.md#weighted-average) of values. | `WAVG(value)` |
 | `WTAVG` | [Time-weighted average](../api/data/series/smooth.md#weighted-time-average) of values. | `WTAVG(value)` |
 | `EMA` | [Exponential moving average](../api/data/series/smooth.md#exponential-moving-average) of values.<br>The function requires smoothing factor as the first argument. | `EMA(0.1, value)` |
@@ -3128,11 +3128,7 @@ date_parse('31.01.2017 12:36:03.283 Europe/Berlin', 'dd.MM.yyyy HH:mm:ss.SSS ZZZ
 The `date_round` function rounds the input date to the start of the containing [calendar period](#calendar-alignment). The date can be specified as literal date, Unix time in milliseconds or a [calendar expression](../shared/calendar.md#keywords).
 
 ```java
-date_round(varchar date | bigint time, int count varchar unit)
-```
-
-```java
-date_round(calendar_expression, int count varchar unit)
+date_round(varchar date | bigint time | calendar_expression, time_interval)
 ```
 
 ```sql
@@ -3668,7 +3664,7 @@ AND LOWER(tags.file_system) LIKE '%root'
 The `LAG` function provides access to a preceding row at a specified offset from the current position.
 
 ```sql
-LAG(varchar columnName [, integer offset [, defaultValue]])
+LAG(scalar_expression [, integer offset [, defaultValue]])
 ```
 
 Example:
@@ -3763,7 +3759,7 @@ WHERE entity = 'nurswgvml007'
 The `LEAD` function provides access to a following row at a specified offset from the current position.
 
 ```sql
-LEAD(varchar columnName [, integer offset [, defaultValue]])
+LEAD(scalar_expression [, integer offset [, defaultValue]])
 ```
 
 Example:
@@ -3784,7 +3780,7 @@ The `LEAD` function operates similarly to the [`LAG`](#lag) function except that
 The `FIRST_VALUE` is an analytical function that returns the first row within the partition.
 
 ```sql
-FIRST_VALUE(varchar columnName)
+FIRST_VALUE(scalar_expression)
 ```
 
 Example:


### PR DESCRIPTION
Replaced `int count varchar unit` with `time_interval`, `varchar columnName` with `scalar_expression`

I think it is more correct to refer to time interval expressions as time_interval instead of `int count varchar unit` since varchar constants are quoted, and set of allowed values needs to be specified.
As for LAG/LEAD functions, we do support expressions in first argument. In MS SQL it is called `scalar expression`, in Oracle – `value expression`